### PR TITLE
fix: ExportOptions method app-store-connect 변경

### DIFF
--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>method</key>
-    <string>app-store</string>
+    <string>app-store-connect</string>
     <key>teamID</key>
     <string>T7U9UX39U3</string>
     <key>signingStyle</key>


### PR DESCRIPTION
CI/CD exportArchive 단계에서 deprecated 경고 제거\n- method: app-store → app-store-connect