### PR TITLE
fix: CI/CD Archive 서명 Automatic으로 변경

### DIFF
--- a/.github/workflows/deploy_ios.yml
+++ b/.github/workflows/deploy_ios.yml
@@ -83,8 +83,7 @@ jobs:
             -authenticationKeyID ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }} \
             -authenticationKeyIssuerID ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }} \
             -authenticationKeyPath ~/.private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8 \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
+            CODE_SIGN_STYLE=Automatic \
             DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }}
 
       - name: Export IPA

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -7,9 +7,7 @@
     <key>teamID</key>
     <string>T7U9UX39U3</string>
     <key>signingStyle</key>
-    <string>manual</string>
-    <key>signingCertificate</key>
-    <string>Apple Distribution</string>
+    <string>automatic</string>
     <key>uploadBitcode</key>
     <false/>
     <key>uploadSymbols</key>


### PR DESCRIPTION
- Manual 서명 시 Sign in with Apple 프로비저닝 프로파일 누락 오류 수정
- Archive: CODE_SIGN_STYLE=Automatic (인증서는 Keychain import 유지)
- ExportOptions: signingStyle automatic으로 변경