### PR TITLE
fix: 프로비저닝 프로파일 수동 설치 및 Export manual 서명

### DIFF
--- a/.github/workflows/deploy_ios.yml
+++ b/.github/workflows/deploy_ios.yml
@@ -71,6 +71,15 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -k "" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
 
+      - name: Install Provisioning Profile
+        env:
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          PP_PATH=$RUNNER_TEMP/bowling_diary.mobileprovision
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > $PP_PATH
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles/
+
       - name: Setup App Store Connect API Key
         run: |
           mkdir -p ~/.private_keys
@@ -99,11 +108,7 @@ jobs:
           xcodebuild -exportArchive \
             -archivePath $RUNNER_TEMP/Runner.xcarchive \
             -exportPath $RUNNER_TEMP/Runner \
-            -exportOptionsPlist ios/ExportOptions.plist \
-            -allowProvisioningUpdates \
-            -authenticationKeyID ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }} \
-            -authenticationKeyIssuerID ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }} \
-            -authenticationKeyPath ~/.private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
+            -exportOptionsPlist ios/ExportOptions.plist
 
       - name: Upload to TestFlight
         uses: apple-actions/upload-testflight-build@v3

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -7,7 +7,14 @@
     <key>teamID</key>
     <string>T7U9UX39U3</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
+    <key>signingCertificate</key>
+    <string>Apple Distribution</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>com.devpark.bowlingDiary</key>
+        <string>bowling_diary_appstore</string>
+    </dict>
     <key>uploadBitcode</key>
     <false/>
     <key>uploadSymbols</key>


### PR DESCRIPTION
- App Store 배포용 프로비저닝 프로파일 수동 설치 추가
- ExportOptions manual 서명 + 프로파일 명시
- Export 단계에서 API key 의존성 제거