### PR TITLE
fix: TestFlight 업로드 xcrun altool 직접 사용

### DIFF
--- a/.github/workflows/deploy_ios.yml
+++ b/.github/workflows/deploy_ios.yml
@@ -111,9 +111,10 @@ jobs:
             -exportOptionsPlist ios/ExportOptions.plist
 
       - name: Upload to TestFlight
-        uses: apple-actions/upload-testflight-build@v3
-        with:
-          app-path: ${{ runner.temp }}/Runner/bowling_diary.ipa
-          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          api-key-id: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          api-private-key: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          xcrun altool --upload-app \
+            -t ios \
+            -f $RUNNER_TEMP/Runner/bowling_diary.ipa \
+            --apiKey ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }} \
+            --apiIssuer ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }} \
+            --output-format xml


### PR DESCRIPTION
apple-actions/upload-testflight-build가 api-private-key로 키 파일을 덮어쓰는 문제 수정
xcrun altool을 직접 호출하여 우리가 설치한 키 파일 사용