### PR TITLE
feat: 버전 1.1.0 및 CI 빌드 번호 자동 증가

### DIFF
--- a/.github/workflows/deploy_ios.yml
+++ b/.github/workflows/deploy_ios.yml
@@ -87,7 +87,12 @@ jobs:
             > ~/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
 
       - name: Build Flutter iOS (no codesign)
-        run: flutter build ios --release --no-codesign --dart-define-from-file=dart_defines.json
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
+          flutter build ios --release --no-codesign \
+            --dart-define-from-file=dart_defines.json \
+            --build-name=$VERSION \
+            --build-number=$((GITHUB_RUN_NUMBER + 10))
 
       - name: Archive
         run: |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bowling_diary
 description: "볼링 기록 & 분석 앱 - 나의 볼링 성장 일기장"
 publish_to: 'none'
-version: 1.0.0+1
+version: 1.1.0+1
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
## Summary
- `pubspec.yaml` 버전을 `1.0.0+1` → `1.1.0+1`으로 업데이트
- CI 워크플로우에서 빌드 번호를 `GITHUB_RUN_NUMBER + 10`으로 자동 설정
  - App Store에 이미 존재하는 빌드 번호(3)와 충돌 방지
- `pubspec.yaml`에서 버전 문자열을 자동 추출하여 `--build-name`에 적용

## Test plan
- [ ] PR merge 후 GitHub Actions 워크플로우 실행 확인
- [ ] TestFlight에 빌드 번호 충돌 없이 업로드 확인
- [ ] 앱 버전이 1.1.0으로 표시되는지 확인