### PR TITLE
fix: Xcode 26 SDK 적용 (App Store 4/28 요건 대응)

### DIFF
--- a/.github/workflows/deploy_ios.yml
+++ b/.github/workflows/deploy_ios.yml
@@ -7,11 +7,14 @@ on:
 
 jobs:
   deploy:
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary
- `runs-on: macos-latest` → `macos-26` 변경 (iOS 26 SDK 포함 러너)
- Xcode 26 명시적 선택 스텝 추가

## 배경
App Store Connect에서 4월 28일부터 iOS 26 SDK(Xcode 26) 빌드 필수 공지 수신.
현재 워크플로우는 iOS 18.5 SDK로 빌드 중 → 기한 전 수정 필요.

## Test plan
- [ ] PR 머지 후 main 푸시 → GitHub Actions 빌드 성공 확인
- [ ] TestFlight에 새 빌드 업로드 확인