### PR TITLE
fix: iOS 26 Platform 설치 및 Xcode 경로 동적 탐색

### DIFF
--- a/.github/workflows/deploy_ios.yml
+++ b/.github/workflows/deploy_ios.yml
@@ -14,7 +14,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
+        run: |
+          XCODE_PATH=$(ls /Applications/ | grep -E '^Xcode_26' | head -1)
+          sudo xcode-select -s /Applications/$XCODE_PATH/Contents/Developer
+          xcodebuild -version
+
+      - name: Install iOS 26 Platform
+        run: xcodebuild -downloadPlatform iOS
+        timeout-minutes: 10
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary
- Xcode 26 경로를 하드코딩 대신 `/Applications/Xcode_26*`으로 동적 탐색 (마이너 버전 대응)
- `xcodebuild -downloadPlatform iOS` 스텝 추가 — iOS 26 Platform 미설치 오류 수정

## 배경
PR #14 머지 후 CI 실패: `Error (Xcode): iOS 26.0 Platform Not Installed`
macos-26 러너에 Xcode 26은 있으나 iOS Platform 컴포넌트가 별도 설치 필요.

## Test plan
- [ ] CI 빌드 성공 확인
- [ ] TestFlight 새 빌드 업로드 확인