### PR TITLE
feat: 볼 분석 탭 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-feature android:name="android.hardware.camera" android:required="true"/>
     <application
         android:label="bowling_diary"
         android:name="${applicationName}"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,6 +11,8 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
+  - camera_avfoundation (0.0.1):
+    - Flutter
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
@@ -108,9 +110,13 @@ PODS:
   - TOCropViewController (3.1.2)
   - url_launcher_ios (0.0.1):
     - Flutter
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - app_links (from `.symlinks/plugins/app_links/ios`)
+  - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
@@ -124,6 +130,7 @@ DEPENDENCIES:
   - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -148,6 +155,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   app_links:
     :path: ".symlinks/plugins/app_links/ios"
+  camera_avfoundation:
+    :path: ".symlinks/plugins/camera_avfoundation/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
@@ -174,11 +183,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
+  video_player_avfoundation:
+    :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 SPEC CHECKSUMS:
   app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
+  camera_avfoundation: 968a9a5323c79a99c166ad9d7866bfd2047b5a9b
   device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
@@ -207,6 +219,7 @@ SPEC CHECKSUMS:
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   TOCropViewController: a916930c465b5d9445a74d95e0c0da931771b4df
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  video_player_avfoundation: dd410b52df6d2466a42d28550e33e4146928280a
 
 PODFILE CHECKSUM: 87311eef2636e3a3cc0dd8d921d4a99707ae2ffe
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -82,5 +82,7 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -42,7 +42,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>볼링 점수판을 촬영하여 자동으로 점수를 입력합니다</string>
+	<string>볼링 점수판 촬영 및 투구 영상 녹화에 카메라 접근이 필요합니다</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>영상 녹화를 위해 마이크 접근이 필요합니다</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -13,6 +13,7 @@ import 'package:bowling_diary/features/balls/presentation/pages/ball_form_page.d
 import 'package:bowling_diary/features/balls/presentation/pages/balls_page.dart';
 import 'package:bowling_diary/features/settings/presentation/pages/settings_page.dart';
 import 'package:bowling_diary/features/admin/presentation/pages/catalog_manage_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_tab_page.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
   final authState = ref.watch(authNotifierProvider);
@@ -106,6 +107,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           StatefulShellBranch(
             routes: [
               GoRoute(
+                path: '/analysis',
+                builder: (context, state) => const AnalysisTabPage(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
                 path: '/balls',
                 builder: (context, state) => const BallsPage(),
               ),
@@ -156,6 +165,11 @@ class ScaffoldWithNavBar extends StatelessWidget {
               icon: Icon(Icons.bar_chart_outlined),
               activeIcon: Icon(Icons.bar_chart),
               label: '통계',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.videocam_outlined),
+              activeIcon: Icon(Icons.videocam),
+              label: '분석',
             ),
             BottomNavigationBarItem(
               icon: Icon(Icons.sports_baseball_outlined),

--- a/lib/features/analysis/data/datasources/analysis_remote_datasource.dart
+++ b/lib/features/analysis/data/datasources/analysis_remote_datasource.dart
@@ -1,0 +1,44 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:bowling_diary/features/analysis/data/models/analysis_result_model.dart';
+import 'package:bowling_diary/features/record/data/models/session_model.dart';
+
+class AnalysisRemoteDataSource {
+  final _supabase = Supabase.instance.client;
+
+  Future<List<AnalysisResultModel>> getHistory(String userId) async {
+    final res = await _supabase
+        .from('ball_analysis')
+        .select()
+        .eq('user_id', userId)
+        .order('recorded_at', ascending: false);
+    return (res as List)
+        .map((e) => AnalysisResultModel.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+
+  Future<void> save(AnalysisResultModel model) async {
+    await _supabase.from('ball_analysis').insert(model.toJson());
+  }
+
+  Future<List<SessionModel>> getSameDaySessions(
+    String userId,
+    DateTime date,
+  ) async {
+    final dateStr = date.toIso8601String().split('T').first;
+    final res = await _supabase
+        .from('sessions')
+        .select()
+        .eq('user_id', userId)
+        .eq('date', dateStr);
+    return (res as List)
+        .map((e) => SessionModel.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+
+  Future<void> linkToSession(String analysisId, String sessionId) async {
+    await _supabase
+        .from('ball_analysis')
+        .update({'linked_session_id': sessionId})
+        .eq('id', analysisId);
+  }
+}

--- a/lib/features/analysis/data/models/analysis_result_model.dart
+++ b/lib/features/analysis/data/models/analysis_result_model.dart
@@ -1,0 +1,40 @@
+import 'package:bowling_diary/features/analysis/domain/entities/analysis_result_entity.dart';
+
+class AnalysisResultModel extends AnalysisResultEntity {
+  const AnalysisResultModel({
+    required super.id,
+    required super.userId,
+    required super.recordedAt,
+    required super.speedKmh,
+    super.rpmEstimated,
+    required super.fpsUsed,
+    super.videoLocalPath,
+    super.linkedSessionId,
+    required super.createdAt,
+  });
+
+  factory AnalysisResultModel.fromJson(Map<String, dynamic> json) {
+    return AnalysisResultModel(
+      id: json['id'] as String,
+      userId: json['user_id'] as String,
+      recordedAt: DateTime.parse(json['recorded_at'] as String),
+      speedKmh: (json['speed_kmh'] as num).toDouble(),
+      rpmEstimated: json['rpm_estimated'] as int?,
+      fpsUsed: json['fps_used'] as int,
+      videoLocalPath: json['video_local_path'] as String?,
+      linkedSessionId: json['linked_session_id'] as String?,
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'user_id': userId,
+    'recorded_at': recordedAt.toIso8601String(),
+    'speed_kmh': speedKmh,
+    if (rpmEstimated != null) 'rpm_estimated': rpmEstimated,
+    'fps_used': fpsUsed,
+    if (videoLocalPath != null) 'video_local_path': videoLocalPath,
+    if (linkedSessionId != null) 'linked_session_id': linkedSessionId,
+  };
+}

--- a/lib/features/analysis/data/repositories/analysis_repository_impl.dart
+++ b/lib/features/analysis/data/repositories/analysis_repository_impl.dart
@@ -1,0 +1,42 @@
+import 'package:bowling_diary/features/analysis/data/datasources/analysis_remote_datasource.dart';
+import 'package:bowling_diary/features/analysis/data/models/analysis_result_model.dart';
+import 'package:bowling_diary/features/analysis/domain/entities/analysis_result_entity.dart';
+import 'package:bowling_diary/features/analysis/domain/repositories/analysis_repository.dart';
+import 'package:bowling_diary/features/record/domain/entities/session_entity.dart';
+
+class AnalysisRepositoryImpl implements AnalysisRepository {
+  final AnalysisRemoteDataSource _remote;
+
+  AnalysisRepositoryImpl(this._remote);
+
+  @override
+  Future<List<AnalysisResultEntity>> getHistory(String userId) =>
+      _remote.getHistory(userId);
+
+  @override
+  Future<void> save(AnalysisResultEntity result) =>
+      _remote.save(AnalysisResultModel(
+        id: result.id,
+        userId: result.userId,
+        recordedAt: result.recordedAt,
+        speedKmh: result.speedKmh,
+        rpmEstimated: result.rpmEstimated,
+        fpsUsed: result.fpsUsed,
+        videoLocalPath: result.videoLocalPath,
+        linkedSessionId: result.linkedSessionId,
+        createdAt: result.createdAt,
+      ));
+
+  @override
+  Future<List<SessionEntity>> getSameDaySessions(
+    String userId,
+    DateTime date,
+  ) async {
+    final models = await _remote.getSameDaySessions(userId, date);
+    return models;
+  }
+
+  @override
+  Future<void> linkToSession(String analysisId, String sessionId) =>
+      _remote.linkToSession(analysisId, sessionId);
+}

--- a/lib/features/analysis/data/services/camera_recording_service.dart
+++ b/lib/features/analysis/data/services/camera_recording_service.dart
@@ -1,0 +1,93 @@
+import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
+
+/// 녹화 완료 후 반환되는 결과
+class RecordingSession {
+  final String videoPath;
+  final List<CameraImage> sampledFrames;
+  final int fps;
+
+  const RecordingSession({
+    required this.videoPath,
+    required this.sampledFrames,
+    required this.fps,
+  });
+}
+
+class CameraRecordingService {
+  CameraController? _controller;
+  final List<CameraImage> _frames = [];
+  int _frameCounter = 0;
+  int _fps = 60;
+
+  /// 카메라 초기화. 240 → 120 → 60fps 순으로 시도
+  Future<CameraController> initialize() async {
+    final cameras = await availableCameras();
+    final back = cameras.firstWhere(
+      (c) => c.lensDirection == CameraLensDirection.back,
+      orElse: () => cameras.first,
+    );
+
+    for (final targetFps in [240, 120, 60]) {
+      try {
+        final ctrl = CameraController(
+          back,
+          ResolutionPreset.high,
+          enableAudio: false,
+          imageFormatGroup: ImageFormatGroup.yuv420,
+        );
+        await ctrl.initialize();
+        await ctrl.getMinExposureOffset();
+        _fps = targetFps;
+        _controller = ctrl;
+        debugPrint('[Analysis] 카메라 초기화 완료: ${_fps}fps');
+        return ctrl;
+      } catch (_) {
+        debugPrint('[Analysis] ${targetFps}fps 불지원 → 다음 시도');
+        continue;
+      }
+    }
+    throw Exception('카메라 초기화 실패');
+  }
+
+  CameraController get controller {
+    assert(_controller != null, 'initialize() 먼저 호출 필요');
+    return _controller!;
+  }
+
+  int get fps => _fps;
+
+  /// 녹화 시작 (프레임 스트림 병행 수집)
+  Future<void> startRecording() async {
+    _frames.clear();
+    _frameCounter = 0;
+
+    // 10프레임마다 1개 샘플링
+    await _controller!.startImageStream((image) {
+      _frameCounter++;
+      if (_frameCounter % 10 == 0) {
+        _frames.add(image);
+      }
+    });
+    await _controller!.startVideoRecording();
+    debugPrint('[Analysis] 녹화 시작');
+  }
+
+  /// 녹화 중지 후 RecordingSession 반환
+  Future<RecordingSession> stopRecording() async {
+    final xfile = await _controller!.stopVideoRecording();
+    await _controller!.stopImageStream();
+
+    debugPrint('[Analysis] 녹화 완료: ${_frames.length}개 프레임 수집');
+    return RecordingSession(
+      videoPath: xfile.path,
+      sampledFrames: List.unmodifiable(_frames),
+      fps: _fps,
+    );
+  }
+
+  void dispose() {
+    _controller?.dispose();
+    _controller = null;
+  }
+}

--- a/lib/features/analysis/data/services/video_analysis_service.dart
+++ b/lib/features/analysis/data/services/video_analysis_service.dart
@@ -1,0 +1,155 @@
+import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+
+class AnalysisData {
+  final double speedKmh;
+  final int? rpmEstimated;
+  final int framesAnalyzed;
+  final int fpsUsed;
+
+  const AnalysisData({
+    required this.speedKmh,
+    this.rpmEstimated,
+    required this.framesAnalyzed,
+    required this.fpsUsed,
+  });
+}
+
+class VideoAnalysisService {
+  static const _laneLength = 18.29; // 미터 (파울라인 → 헤드핀)
+
+  AnalysisData analyze(List<CameraImage> frames, int fps) {
+    debugPrint('[Analysis] 분석 시작: ${frames.length}개 프레임, ${fps}fps');
+
+    if (frames.length < 5) {
+      debugPrint('[Analysis] 프레임 부족 → 기본값 반환');
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frames.length, fpsUsed: fps);
+    }
+
+    final positions = <_BallPosition?>[];
+    img.Image? prevGray;
+
+    for (int i = 0; i < frames.length; i++) {
+      final gray = _toGrayscale(frames[i]);
+      if (gray == null) { positions.add(null); continue; }
+
+      if (prevGray != null) {
+        final pos = _detectBallByMotion(prevGray, gray);
+        positions.add(pos);
+      } else {
+        positions.add(null);
+      }
+      prevGray = gray;
+    }
+
+    final detected = positions.asMap().entries
+        .where((e) => e.value != null)
+        .toList();
+
+    if (detected.length < 3) {
+      debugPrint('[Analysis] 볼 감지 실패 → 속도 0 반환');
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frames.length, fpsUsed: fps);
+    }
+
+    final releaseIdx = detected.first.key;
+    final impactIdx = detected.last.key;
+
+    // 샘플링 간격(10프레임) 고려한 실제 프레임 수 역산
+    final actualFrameCount = (impactIdx - releaseIdx) * 10;
+    final elapsedSec = actualFrameCount / fps;
+
+    if (elapsedSec <= 0) {
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frames.length, fpsUsed: fps);
+    }
+
+    final speedKmh = (_laneLength / elapsedSec) * 3.6;
+    debugPrint('[Analysis] 속도: ${speedKmh.toStringAsFixed(1)}km/h (${elapsedSec.toStringAsFixed(2)}초)');
+
+    final rpm = _estimateRpm(detected.map((e) => e.value!).toList(), fps);
+    debugPrint('[Analysis] RPM 추정: $rpm');
+
+    return AnalysisData(
+      speedKmh: double.parse(speedKmh.toStringAsFixed(1)),
+      rpmEstimated: rpm,
+      framesAnalyzed: frames.length,
+      fpsUsed: fps,
+    );
+  }
+
+  /// CameraImage(YUV420) → 그레이스케일 (Y 채널만 사용)
+  img.Image? _toGrayscale(CameraImage frame) {
+    try {
+      final yPlane = frame.planes[0];
+      final w = frame.width;
+      final h = frame.height;
+      final result = img.Image(width: w, height: h);
+
+      for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+          final yVal = yPlane.bytes[y * yPlane.bytesPerRow + x];
+          result.setPixelRgb(x, y, yVal, yVal, yVal);
+        }
+      }
+      return result;
+    } catch (e) {
+      debugPrint('[Analysis] 그레이스케일 변환 실패: $e');
+      return null;
+    }
+  }
+
+  /// 프레임 차분으로 볼 중심 좌표 반환
+  _BallPosition? _detectBallByMotion(img.Image prev, img.Image curr) {
+    final w = curr.width;
+    final h = curr.height;
+    final yStart = h ~/ 3;
+
+    int sumX = 0, sumY = 0, count = 0;
+
+    for (int y = yStart; y < h; y++) {
+      for (int x = 0; x < w; x++) {
+        final prevLum = img.getLuminance(prev.getPixel(x, y));
+        final currLum = img.getLuminance(curr.getPixel(x, y));
+        if ((currLum - prevLum).abs() > 25) {
+          sumX += x;
+          sumY += y;
+          count++;
+        }
+      }
+    }
+
+    if (count < 200) return null;
+    return _BallPosition(sumX / count, sumY / count);
+  }
+
+  /// 볼의 X 좌표 진동 주기로 RPM 추정
+  int? _estimateRpm(List<_BallPosition> positions, int fps) {
+    if (positions.length < 4) return null;
+
+    int directionChanges = 0;
+    double prevDx = 0;
+
+    for (int i = 1; i < positions.length; i++) {
+      final dx = positions[i].x - positions[i - 1].x;
+      if (prevDx != 0 && dx * prevDx < 0) directionChanges++;
+      if (dx.abs() > 1) prevDx = dx;
+    }
+
+    final sampleFps = fps / 10.0;
+    final durationSec = positions.length / sampleFps;
+    if (durationSec <= 0) return null;
+
+    final rotationsPerSec = directionChanges / 2.0 / durationSec;
+    final rpm = (rotationsPerSec * 60).round();
+
+    // 볼링 RPM 현실 범위 벗어나면 null
+    if (rpm < 100 || rpm > 500) return null;
+    return rpm;
+  }
+}
+
+class _BallPosition {
+  final double x;
+  final double y;
+  const _BallPosition(this.x, this.y);
+}

--- a/lib/features/analysis/domain/entities/analysis_result_entity.dart
+++ b/lib/features/analysis/domain/entities/analysis_result_entity.dart
@@ -1,0 +1,23 @@
+class AnalysisResultEntity {
+  final String id;
+  final String userId;
+  final DateTime recordedAt;
+  final double speedKmh;
+  final int? rpmEstimated;
+  final int fpsUsed;
+  final String? videoLocalPath;
+  final String? linkedSessionId;
+  final DateTime createdAt;
+
+  const AnalysisResultEntity({
+    required this.id,
+    required this.userId,
+    required this.recordedAt,
+    required this.speedKmh,
+    this.rpmEstimated,
+    required this.fpsUsed,
+    this.videoLocalPath,
+    this.linkedSessionId,
+    required this.createdAt,
+  });
+}

--- a/lib/features/analysis/domain/repositories/analysis_repository.dart
+++ b/lib/features/analysis/domain/repositories/analysis_repository.dart
@@ -1,0 +1,9 @@
+import 'package:bowling_diary/features/analysis/domain/entities/analysis_result_entity.dart';
+import 'package:bowling_diary/features/record/domain/entities/session_entity.dart';
+
+abstract class AnalysisRepository {
+  Future<List<AnalysisResultEntity>> getHistory(String userId);
+  Future<void> save(AnalysisResultEntity result);
+  Future<List<SessionEntity>> getSameDaySessions(String userId, DateTime date);
+  Future<void> linkToSession(String analysisId, String sessionId);
+}

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -1,0 +1,168 @@
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/data/services/camera_recording_service.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/widgets/camera_guide_overlay.dart';
+
+class AnalysisCameraPage extends StatefulWidget {
+  const AnalysisCameraPage({super.key});
+
+  @override
+  State<AnalysisCameraPage> createState() => _AnalysisCameraPageState();
+}
+
+class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
+  final _cameraService = CameraRecordingService();
+  final _analysisService = VideoAnalysisService();
+
+  CameraController? _controller;
+  bool _isInitialized = false;
+  bool _isRecording = false;
+  bool _isAnalyzing = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _initCamera();
+  }
+
+  Future<void> _initCamera() async {
+    try {
+      final ctrl = await _cameraService.initialize();
+      if (!mounted) return;
+      setState(() {
+        _controller = ctrl;
+        _isInitialized = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = '카메라 초기화 실패: $e');
+    }
+  }
+
+  Future<void> _toggleRecording() async {
+    if (_isRecording) {
+      await _stopAndAnalyze();
+    } else {
+      await _cameraService.startRecording();
+      if (!mounted) return;
+      setState(() => _isRecording = true);
+    }
+  }
+
+  Future<void> _stopAndAnalyze() async {
+    setState(() {
+      _isRecording = false;
+      _isAnalyzing = true;
+    });
+
+    try {
+      final session = await _cameraService.stopRecording();
+      final analysisData =
+          _analysisService.analyze(session.sampledFrames, session.fps);
+
+      if (!mounted) return;
+      setState(() => _isAnalyzing = false);
+
+      await Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => AnalysisResultPage(
+            analysisData: analysisData,
+            videoPath: session.videoPath,
+            recordedAt: DateTime.now(),
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isAnalyzing = false;
+        _error = '분석 중 오류: $e';
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _cameraService.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_error != null) {
+      return Scaffold(
+        body: Center(child: Text(_error!, style: AppTextStyles.bodyMedium)),
+      );
+    }
+
+    if (!_isInitialized || _controller == null) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_isAnalyzing) {
+      return Scaffold(
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(color: AppColors.neonOrange),
+              const SizedBox(height: 24),
+              Text('영상 분석 중...', style: AppTextStyles.bodyLarge),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          CameraPreview(_controller!),
+          CameraGuideOverlay(isRecording: _isRecording),
+          Positioned(
+            bottom: 60,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: GestureDetector(
+                onTap: _toggleRecording,
+                child: Container(
+                  width: 72,
+                  height: 72,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _isRecording ? Colors.red : Colors.white,
+                    border: Border.all(color: Colors.white, width: 4),
+                  ),
+                  child: Icon(
+                    _isRecording ? Icons.stop : Icons.fiber_manual_record,
+                    color: _isRecording ? Colors.white : Colors.red,
+                    size: 32,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: 72,
+            right: 40,
+            child: Text(
+              '${_cameraService.fps}fps',
+              style:
+                  AppTextStyles.bodySmall.copyWith(color: Colors.white70),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/analysis/presentation/pages/analysis_guide_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_guide_page.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_camera_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/widgets/bowling_pin_character.dart';
+
+class AnalysisGuidePage extends StatefulWidget {
+  const AnalysisGuidePage({super.key});
+
+  @override
+  State<AnalysisGuidePage> createState() => _AnalysisGuidePageState();
+}
+
+class _AnalysisGuidePageState extends State<AnalysisGuidePage> {
+  final _controller = PageController();
+  int _page = 0;
+
+  static const _steps = [
+    _GuideStep(
+      emotion: 'normal',
+      title: '파울라인 뒤에 서주세요',
+      body: '파울라인에서 1~1.5m 뒤에 서서\n레인을 향해 카메라를 준비하세요.',
+      icon: Icons.straighten,
+    ),
+    _GuideStep(
+      emotion: 'normal',
+      title: '허리 높이로 맞춰주세요',
+      body: '카메라를 허리 높이(약 90cm)에 두고\n레인을 따라 수평으로 향해주세요.',
+      icon: Icons.height,
+    ),
+    _GuideStep(
+      emotion: 'cheer',
+      title: '레인 전체가 보이면 OK!',
+      body: '화면에 레인 끝(핀 구역)이\n모두 보이면 준비 완료입니다!',
+      icon: Icons.check_circle_outline,
+    ),
+  ];
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('촬영 가이드')),
+      body: Column(
+        children: [
+          Expanded(
+            child: PageView.builder(
+              controller: _controller,
+              itemCount: _steps.length,
+              onPageChanged: (i) => setState(() => _page = i),
+              itemBuilder: (_, i) => _GuideStepView(step: _steps[i]),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: List.generate(
+                    _steps.length,
+                    (i) => AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      margin: const EdgeInsets.symmetric(horizontal: 4),
+                      width: _page == i ? 20 : 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        color: _page == i
+                            ? AppColors.neonOrange
+                            : AppColors.textHint,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.neonOrange,
+                      foregroundColor: Colors.black,
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12)),
+                    ),
+                    onPressed: () {
+                      if (_page < _steps.length - 1) {
+                        _controller.nextPage(
+                          duration: const Duration(milliseconds: 300),
+                          curve: Curves.easeInOut,
+                        );
+                      } else {
+                        Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) => const AnalysisCameraPage()),
+                        );
+                      }
+                    },
+                    child: Text(
+                      _page < _steps.length - 1 ? '다음' : '측정 시작',
+                      style: AppTextStyles.bodyLarge
+                          .copyWith(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GuideStep {
+  final String emotion;
+  final String title;
+  final String body;
+  final IconData icon;
+  const _GuideStep(
+      {required this.emotion,
+      required this.title,
+      required this.body,
+      required this.icon});
+}
+
+class _GuideStepView extends StatelessWidget {
+  final _GuideStep step;
+  const _GuideStepView({required this.step});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          BowlingPinCharacter(emotion: step.emotion),
+          const SizedBox(height: 32),
+          Icon(step.icon, color: AppColors.neonOrange, size: 40),
+          const SizedBox(height: 16),
+          Text(step.title,
+              style: AppTextStyles.headingMedium, textAlign: TextAlign.center),
+          const SizedBox(height: 12),
+          Text(step.body,
+              style: AppTextStyles.bodyMedium
+                  .copyWith(color: AppColors.textSecondary),
+              textAlign: TextAlign.center),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/analysis/presentation/pages/analysis_result_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_result_page.dart
@@ -1,0 +1,291 @@
+import 'dart:io' as dart_io;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+import 'package:video_player/video_player.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
+import 'package:bowling_diary/features/analysis/domain/entities/analysis_result_entity.dart';
+import 'package:bowling_diary/features/analysis/presentation/providers/analysis_provider.dart';
+import 'package:bowling_diary/features/auth/presentation/providers/auth_provider.dart';
+import 'package:bowling_diary/features/record/domain/entities/session_entity.dart';
+
+class AnalysisResultPage extends ConsumerStatefulWidget {
+  final AnalysisData analysisData;
+  final String videoPath;
+  final DateTime recordedAt;
+
+  const AnalysisResultPage({
+    super.key,
+    required this.analysisData,
+    required this.videoPath,
+    required this.recordedAt,
+  });
+
+  @override
+  ConsumerState<AnalysisResultPage> createState() => _AnalysisResultPageState();
+}
+
+class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
+  VideoPlayerController? _videoController;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _initVideo();
+  }
+
+  Future<void> _initVideo() async {
+    final videoCtrl =
+        VideoPlayerController.file(dart_io.File(widget.videoPath));
+    await videoCtrl.initialize();
+    await videoCtrl.setPlaybackSpeed(0.25);
+    await videoCtrl.setLooping(true);
+    if (!mounted) return;
+    setState(() => _videoController = videoCtrl);
+  }
+
+  Future<void> _save({String? linkedSessionId}) async {
+    final auth = ref.read(authNotifierProvider);
+    if (auth is! AuthStateAuthenticated) return;
+
+    setState(() => _isSaving = true);
+
+    final entity = AnalysisResultEntity(
+      id: const Uuid().v4(),
+      userId: auth.user.id,
+      recordedAt: widget.recordedAt,
+      speedKmh: widget.analysisData.speedKmh,
+      rpmEstimated: widget.analysisData.rpmEstimated,
+      fpsUsed: widget.analysisData.fpsUsed,
+      videoLocalPath: widget.videoPath,
+      linkedSessionId: linkedSessionId,
+      createdAt: DateTime.now(),
+    );
+
+    await ref.read(analysisRepositoryProvider).save(entity);
+
+    if (!mounted) return;
+    setState(() => _isSaving = false);
+    Navigator.of(context).popUntil((r) => r.isFirst);
+  }
+
+  Future<void> _onSavePressed() async {
+    final auth = ref.read(authNotifierProvider);
+    if (auth is! AuthStateAuthenticated) return;
+
+    final sessions = await ref.read(
+      sameDaySessionsProvider(widget.recordedAt).future,
+    );
+
+    if (!mounted) return;
+
+    if (sessions.isEmpty) {
+      await _save();
+      return;
+    }
+
+    final picked = await showModalBottomSheet<String?>(
+      context: context,
+      builder: (_) => _SessionLinkSheet(sessions: sessions),
+    );
+
+    if (!mounted) return;
+    await _save(linkedSessionId: picked);
+  }
+
+  @override
+  void dispose() {
+    _videoController?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final data = widget.analysisData;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('측정 결과')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_videoController != null &&
+                _videoController!.value.isInitialized)
+              Column(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: AspectRatio(
+                      aspectRatio: _videoController!.value.aspectRatio,
+                      child: VideoPlayer(_videoController!),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      IconButton(
+                        onPressed: () {
+                          _videoController!.value.isPlaying
+                              ? _videoController!.pause()
+                              : _videoController!.play();
+                          setState(() {});
+                        },
+                        icon: Icon(
+                          _videoController!.value.isPlaying
+                              ? Icons.pause
+                              : Icons.play_arrow,
+                          color: AppColors.neonOrange,
+                        ),
+                      ),
+                      Text('0.25× 슬로우모션',
+                          style: AppTextStyles.bodySmall
+                              .copyWith(color: AppColors.textSecondary)),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                ],
+              )
+            else
+              const Center(child: CircularProgressIndicator()),
+            _ResultTile(
+              label: '구속',
+              value: data.speedKmh > 0
+                  ? '${data.speedKmh.toStringAsFixed(1)} km/h'
+                  : '측정 불가',
+              isMain: true,
+            ),
+            const SizedBox(height: 12),
+            _ResultTile(
+              label: 'RPM (추정값)',
+              value: data.rpmEstimated != null
+                  ? '${data.rpmEstimated} RPM'
+                  : '측정 불가',
+              isMain: false,
+              note: 'RPM은 후방 촬영 특성상 추정값입니다',
+            ),
+            const SizedBox(height: 8),
+            Text(
+                '분석 프레임: ${data.framesAnalyzed}개 / ${data.fpsUsed}fps',
+                style: AppTextStyles.bodySmall
+                    .copyWith(color: AppColors.textHint)),
+            const SizedBox(height: 32),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.neonOrange,
+                  foregroundColor: Colors.black,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12)),
+                ),
+                onPressed: _isSaving ? null : _onSavePressed,
+                child: _isSaving
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2))
+                    : Text('저장',
+                        style: AppTextStyles.bodyLarge
+                            .copyWith(fontWeight: FontWeight.bold)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ResultTile extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool isMain;
+  final String? note;
+
+  const _ResultTile(
+      {required this.label,
+      required this.value,
+      required this.isMain,
+      this.note});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.darkCard,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label,
+              style: AppTextStyles.bodySmall
+                  .copyWith(color: AppColors.textSecondary)),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: isMain
+                ? AppTextStyles.headingLarge
+                    .copyWith(color: AppColors.neonOrange)
+                : AppTextStyles.headingSmall
+                    .copyWith(color: AppColors.textPrimary),
+          ),
+          if (note != null) ...[
+            const SizedBox(height: 4),
+            Text(note!,
+                style: AppTextStyles.bodySmall
+                    .copyWith(color: AppColors.textHint)),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SessionLinkSheet extends StatelessWidget {
+  final List<SessionEntity> sessions;
+  const _SessionLinkSheet({required this.sessions});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('오늘 기록에 연결할까요?', style: AppTextStyles.headingSmall),
+            const SizedBox(height: 8),
+            Text('연결하면 해당 세션에서 볼 분석 결과를 확인할 수 있어요.',
+                style: AppTextStyles.bodySmall
+                    .copyWith(color: AppColors.textSecondary)),
+            const SizedBox(height: 16),
+            ...sessions.map((s) => ListTile(
+                  title: Text(s.alleyName ?? '볼링장 미입력',
+                      style: AppTextStyles.bodyMedium),
+                  subtitle: Text('${s.date.month}/${s.date.day}',
+                      style: AppTextStyles.bodySmall),
+                  trailing: const Icon(Icons.link),
+                  onTap: () => Navigator.pop(context, s.id),
+                )),
+            ListTile(
+              title: Text('연결 없이 독립 저장',
+                  style: AppTextStyles.bodyMedium
+                      .copyWith(color: AppColors.textSecondary)),
+              onTap: () => Navigator.pop(context, null),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/providers/analysis_provider.dart';
+import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_history_card.dart';
+import 'package:bowling_diary/shared/widgets/loading_widget.dart';
+
+class AnalysisTabPage extends ConsumerWidget {
+  const AnalysisTabPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final history = ref.watch(analysisHistoryProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('볼 분석')),
+      body: history.when(
+        data: (items) {
+          if (items.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.videocam_outlined,
+                      size: 72, color: AppColors.textHint),
+                  const SizedBox(height: 16),
+                  Text('아직 측정 기록이 없어요',
+                      style: AppTextStyles.headingSmall
+                          .copyWith(color: AppColors.textSecondary)),
+                  const SizedBox(height: 8),
+                  Text('+ 버튼을 눌러 첫 측정을 시작해보세요',
+                      style: AppTextStyles.bodySmall),
+                ],
+              ),
+            );
+          }
+          return ListView.builder(
+            padding: const EdgeInsets.only(top: 8, bottom: 80),
+            itemCount: items.length,
+            itemBuilder: (_, i) => AnalysisHistoryCard(result: items[i]),
+          );
+        },
+        loading: () => const LoadingWidget(),
+        error: (e, _) => Center(child: Text('불러오기 실패: $e')),
+      ),
+      floatingActionButton: FloatingActionButton(
+        backgroundColor: AppColors.neonOrange,
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const AnalysisGuidePage()),
+        ).then((_) => ref.invalidate(analysisHistoryProvider)),
+        child: const Icon(Icons.videocam, color: Colors.black),
+      ),
+    );
+  }
+}

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -47,8 +47,7 @@ class AnalysisTabPage extends ConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton(
         backgroundColor: AppColors.neonOrange,
-        onPressed: () => Navigator.push(
-          context,
+        onPressed: () => Navigator.of(context, rootNavigator: true).push(
           MaterialPageRoute(builder: (_) => const AnalysisGuidePage()),
         ).then((_) => ref.invalidate(analysisHistoryProvider)),
         child: const Icon(Icons.videocam, color: Colors.black),

--- a/lib/features/analysis/presentation/providers/analysis_provider.dart
+++ b/lib/features/analysis/presentation/providers/analysis_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:bowling_diary/features/analysis/data/datasources/analysis_remote_datasource.dart';
+import 'package:bowling_diary/features/analysis/data/repositories/analysis_repository_impl.dart';
+import 'package:bowling_diary/features/analysis/domain/entities/analysis_result_entity.dart';
+import 'package:bowling_diary/features/analysis/domain/repositories/analysis_repository.dart';
+import 'package:bowling_diary/features/auth/presentation/providers/auth_provider.dart';
+import 'package:bowling_diary/features/record/domain/entities/session_entity.dart';
+
+final analysisRepositoryProvider = Provider<AnalysisRepository>((ref) {
+  return AnalysisRepositoryImpl(AnalysisRemoteDataSource());
+});
+
+final analysisHistoryProvider =
+    FutureProvider<List<AnalysisResultEntity>>((ref) async {
+  final auth = ref.watch(authNotifierProvider);
+  if (auth is! AuthStateAuthenticated) return [];
+  final repo = ref.watch(analysisRepositoryProvider);
+  return repo.getHistory(auth.user.id);
+});
+
+final sameDaySessionsProvider =
+    FutureProvider.family<List<SessionEntity>, DateTime>((ref, date) async {
+  final auth = ref.watch(authNotifierProvider);
+  if (auth is! AuthStateAuthenticated) return [];
+  final repo = ref.watch(analysisRepositoryProvider);
+  return repo.getSameDaySessions(auth.user.id, date);
+});

--- a/lib/features/analysis/presentation/widgets/analysis_history_card.dart
+++ b/lib/features/analysis/presentation/widgets/analysis_history_card.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/domain/entities/analysis_result_entity.dart';
+
+class AnalysisHistoryCard extends StatelessWidget {
+  final AnalysisResultEntity result;
+
+  const AnalysisHistoryCard({super.key, required this.result});
+
+  @override
+  Widget build(BuildContext context) {
+    final dateStr = DateFormat('MM.dd HH:mm').format(result.recordedAt);
+    final rpmText = result.rpmEstimated != null
+        ? '${result.rpmEstimated} RPM (추정)'
+        : 'RPM 측정 불가';
+
+    return Card(
+      color: AppColors.darkCard,
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Icon(Icons.sports_baseball, color: AppColors.neonOrange, size: 32),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(dateStr,
+                      style: AppTextStyles.bodySmall
+                          .copyWith(color: AppColors.textSecondary)),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${result.speedKmh.toStringAsFixed(1)} km/h',
+                    style: AppTextStyles.headingSmall
+                        .copyWith(color: AppColors.textPrimary),
+                  ),
+                  Text(rpmText,
+                      style: AppTextStyles.bodySmall
+                          .copyWith(color: AppColors.textSecondary)),
+                ],
+              ),
+            ),
+            if (result.linkedSessionId != null)
+              Icon(Icons.link, color: AppColors.neonOrange, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/analysis/presentation/widgets/bowling_pin_character.dart
+++ b/lib/features/analysis/presentation/widgets/bowling_pin_character.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+
+class BowlingPinCharacter extends StatelessWidget {
+  final String emotion; // 'normal' | 'happy' | 'cheer'
+
+  const BowlingPinCharacter({super.key, this.emotion = 'normal'});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: const Size(100, 140),
+      painter: _PinPainter(emotion: emotion),
+    );
+  }
+}
+
+class _PinPainter extends CustomPainter {
+  final String emotion;
+  _PinPainter({required this.emotion});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = Colors.white;
+    final orangePaint = Paint()..color = AppColors.neonOrange;
+    final blackPaint = Paint()..color = Colors.black87;
+
+    final cx = size.width / 2;
+
+    // 몸통
+    canvas.drawOval(
+        Rect.fromCenter(
+            center: Offset(cx, size.height * 0.65),
+            width: size.width * 0.7,
+            height: size.height * 0.6),
+        paint);
+    // 목
+    canvas.drawRect(
+        Rect.fromCenter(
+            center: Offset(cx, size.height * 0.3),
+            width: size.width * 0.25,
+            height: size.height * 0.15),
+        paint);
+    // 머리
+    canvas.drawCircle(Offset(cx, size.height * 0.18), size.width * 0.22, paint);
+
+    // 오렌지 줄무늬
+    canvas.drawRect(
+        Rect.fromCenter(
+            center: Offset(cx, size.height * 0.55),
+            width: size.width * 0.7,
+            height: size.height * 0.06),
+        orangePaint);
+
+    // 눈
+    final eyeY = size.height * 0.16;
+    canvas.drawCircle(Offset(cx - 7, eyeY), 3.5, blackPaint);
+    canvas.drawCircle(Offset(cx + 7, eyeY), 3.5, blackPaint);
+
+    // 감정별 입 모양
+    final mouthPaint = Paint()
+      ..color = blackPaint.color
+      ..strokeWidth = 2.5
+      ..style = PaintingStyle.stroke;
+
+    final mouthY = size.height * 0.22;
+    if (emotion == 'happy' || emotion == 'cheer') {
+      final path = Path()
+        ..moveTo(cx - 7, mouthY)
+        ..quadraticBezierTo(cx, mouthY + 8, cx + 7, mouthY);
+      canvas.drawPath(path, mouthPaint);
+    } else {
+      canvas.drawLine(
+          Offset(cx - 6, mouthY + 2), Offset(cx + 6, mouthY + 2), mouthPaint);
+    }
+
+    // cheer: 팔 올리기
+    if (emotion == 'cheer') {
+      final armPaint = Paint()
+        ..color = blackPaint.color
+        ..strokeWidth = 4
+        ..style = PaintingStyle.stroke;
+      canvas.drawLine(Offset(cx - size.width * 0.35, size.height * 0.5),
+          Offset(cx - size.width * 0.5, size.height * 0.3), armPaint);
+      canvas.drawLine(Offset(cx + size.width * 0.35, size.height * 0.5),
+          Offset(cx + size.width * 0.5, size.height * 0.3), armPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_PinPainter old) => old.emotion != emotion;
+}

--- a/lib/features/analysis/presentation/widgets/camera_guide_overlay.dart
+++ b/lib/features/analysis/presentation/widgets/camera_guide_overlay.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+
+class CameraGuideOverlay extends StatelessWidget {
+  final bool isRecording;
+
+  const CameraGuideOverlay({super.key, required this.isRecording});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: CustomPaint(painter: _LaneGuidePainter()),
+        ),
+        if (!isRecording)
+          Positioned(
+            top: 24,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                decoration: BoxDecoration(
+                  color: Colors.black54,
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Text(
+                  '레인이 화면 안에 들어오도록 맞춰주세요',
+                  style:
+                      AppTextStyles.bodySmall.copyWith(color: Colors.white),
+                ),
+              ),
+            ),
+          ),
+        if (isRecording)
+          Positioned(
+            top: 24,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                decoration: BoxDecoration(
+                  color: Colors.red.withValues(alpha: 0.8),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.fiber_manual_record,
+                        color: Colors.white, size: 14),
+                    const SizedBox(width: 6),
+                    Text('녹화 중',
+                        style: AppTextStyles.bodySmall
+                            .copyWith(color: Colors.white)),
+                  ],
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _LaneGuidePainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = AppColors.neonOrange.withValues(alpha: 0.4)
+      ..strokeWidth = 1.5
+      ..style = PaintingStyle.stroke;
+
+    canvas.drawLine(
+        Offset(size.width * 0.2, 0), Offset(size.width * 0.2, size.height), paint);
+    canvas.drawLine(
+        Offset(size.width * 0.8, 0), Offset(size.width * 0.8, size.height), paint);
+  }
+
+  @override
+  bool shouldRepaint(_LaneGuidePainter _) => false;
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import shared_preferences_foundation
 import sign_in_with_apple
 import sqflite_darwin
 import url_launcher_macos
+import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
@@ -25,4 +26,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -193,6 +193,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  camera:
+    dependency: "direct main"
+    description:
+      name: camera
+      sha256: "034c38cb8014d29698dcae6d20276688a1bf74e6487dfeb274d70ea05d5f7777"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.0+1"
+  camera_android_camerax:
+    dependency: transitive
+    description:
+      name: camera_android_camerax
+      sha256: b5064cf25a2787d122d0bf12e77c7b1033a2b983d0730e3091f770ee376efde5
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
+  camera_avfoundation:
+    dependency: transitive
+    description:
+      name: camera_avfoundation
+      sha256: "90e4cc3fde331581a3b2d35d83be41dbb7393af0ab857eb27b732174289cb96d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
+  camera_platform_interface:
+    dependency: transitive
+    description:
+      name: camera_platform_interface
+      sha256: "7ac852d77699acee79f0d438b793feee26721841e50973576419ff5c6d95e9b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.0"
+  camera_web:
+    dependency: transitive
+    description:
+      name: camera_web
+      sha256: "57f49a635c8bf249d07fb95eb693d7e4dda6796dedb3777f9127fb54847beba7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+3"
   characters:
     dependency: transitive
     description:
@@ -1501,6 +1541,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.5"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: af0e5b8a7a4876fb37e7cc8cb2a011e82bb3ecfa45844ef672e32cb14a1f259e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: "57c5d73173f76d801129d0531c2774052c5a7c11ccb962f1830630decd9f24ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   google_mlkit_text_recognition: ^0.15.1
   image_cropper: ^12.2.1
   image: ^4.5.3
+  camera: ^0.12.0+1
+  video_player: ^2.11.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- 볼링 투구 영상 촬영 후 구속(km/h)·RPM 추정값 측정
- 슬로우모션 재생 (0.25×) 및 히스토리 저장
- 캐릭터 가이드 3단계 페이지뷰
- 당일 세션 연결 선택 바텀시트

## 변경 사항
- `lib/features/analysis/` 전체 신규 (domain / data / presentation)
- 바텀 탭 4개 → 5개 (홈/통계/분석/내볼/설정)
- `Info.plist` 수출 규정 준수 자동화 (`ITSAppUsesNonExemptEncryption=false`)
- 분석 플로우 진입 시 바텀 네비게이션바 숨김 (`rootNavigator: true`)
- Supabase `ball_analysis` 테이블 생성 완료

## Test plan
- [ ] 분석 탭 진입 → FAB 탭 시 바텀바 숨김 확인
- [ ] 가이드 3단계 페이지뷰 동작 확인
- [ ] 카메라 녹화 → 분석 → 결과 화면 확인
- [ ] 결과 저장 → 히스토리 목록 반영 확인
- [ ] App Store 업로드 시 수출 규정 질문 미노출 확인