### PR TITLE
fix: Xcode CI 초기화 방식 수정 (runFirstLaunch)

### DIFF
--- a/.github/workflows/deploy_ios.yml
+++ b/.github/workflows/deploy_ios.yml
@@ -19,9 +19,8 @@ jobs:
           sudo xcode-select -s /Applications/$XCODE_PATH/Contents/Developer
           xcodebuild -version
 
-      - name: Install iOS 26 Platform
-        run: xcodebuild -downloadPlatform iOS
-        timeout-minutes: 10
+      - name: Xcode 첫 실행 초기화 (CI)
+        run: sudo xcodebuild -runFirstLaunch
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary
- `xcodebuild -downloadPlatform iOS` → `sudo xcodebuild -runFirstLaunch` 교체

## 배경
`-downloadPlatform iOS`는 내부적으로 시뮬레이터 데몬에 연결을 시도하는데,
GitHub Actions 헤드리스 환경에는 시뮬레이터가 없어 `Unable to connect to simulator` 오류 발생.
`-runFirstLaunch`는 CI 환경 전용 초기화 커맨드로 시뮬레이터 없이 동작함.