### PR TITLE
fix: iOS 26 플랫폼 다운로드 방식 수정

### DIFF
--- a/.github/workflows/deploy_ios.yml
+++ b/.github/workflows/deploy_ios.yml
@@ -19,8 +19,12 @@ jobs:
           sudo xcode-select -s /Applications/$XCODE_PATH/Contents/Developer
           xcodebuild -version
 
-      - name: Xcode 첫 실행 초기화 (CI)
-        run: sudo xcodebuild -runFirstLaunch
+      - name: Xcode 초기화 및 iOS 플랫폼 설치
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          xcrun simctl list > /dev/null 2>&1 || true
+          xcodebuild -downloadPlatform iOS
+        timeout-minutes: 15
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary
- `xcrun simctl list`로 CoreSimulator 데몬 먼저 초기화
- 이후 `xcodebuild -downloadPlatform iOS` 실행 → 데몬 연결 오류 해결
- `runFirstLaunch`는 유지 (Xcode 기본 초기화)

## 배경
`-downloadPlatform iOS`가 내부적으로 CoreSimulator 데몬에 연결하는데,
데몬이 꺼진 상태라 "Unable to connect to simulator" 오류 발생.
`xcrun simctl list`를 먼저 실행하면 데몬이 깨어나 이후 다운로드가 정상 동작함.