### PR TITLE
feat: 갤러리 영상 볼링공 분석 기능 추가

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,6 +45,8 @@
 	<string>볼링 점수판 촬영 및 투구 영상 녹화에 카메라 접근이 필요합니다</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>영상 녹화를 위해 마이크 접근이 필요합니다</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>갤러리 영상을 불러와 볼링공 속도·RPM을 분석합니다</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,41 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:bowling_diary/app/router/app_router.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_theme.dart';
-import 'package:bowling_diary/shared/providers/theme_provider.dart';
 
-class BowlingDiaryApp extends ConsumerStatefulWidget {
-  const BowlingDiaryApp({super.key});
+/// ProviderScope를 포함한 앱 전체 재시작 위젯
+class AppRestarter extends StatefulWidget {
+  const AppRestarter({super.key});
+
+  static _AppRestarterState of(BuildContext context) =>
+      context.findAncestorStateOfType<_AppRestarterState>()!;
 
   @override
-  ConsumerState<BowlingDiaryApp> createState() => _BowlingDiaryAppState();
+  State<AppRestarter> createState() => _AppRestarterState();
 }
 
-class _BowlingDiaryAppState extends ConsumerState<BowlingDiaryApp>
-    with WidgetsBindingObserver {
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-  }
+class _AppRestarterState extends State<AppRestarter> {
+  Key _key = UniqueKey();
 
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
-
-  @override
-  void didChangePlatformBrightness() {
-    final brightness =
-        WidgetsBinding.instance.platformDispatcher.platformBrightness;
-    ref.read(platformBrightnessProvider.notifier).state = brightness;
-  }
+  /// 호출 시 ProviderScope 포함 전체 재빌드 → 테마 재로드
+  void restart() => setState(() => _key = UniqueKey());
 
   @override
   Widget build(BuildContext context) {
+    return ProviderScope(
+      key: _key,
+      child: const BowlingDiaryApp(),
+    );
+  }
+}
+
+class BowlingDiaryApp extends ConsumerWidget {
+  const BowlingDiaryApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(appRouterProvider);
-    final palette = ref.watch(activePaletteProvider);
+    final palette = AppColors.palette;
     final themeData = AppTheme.fromPalette(palette);
     final themeMode = palette.brightness == Brightness.light
         ? ThemeMode.light

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -2,17 +2,40 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:bowling_diary/app/router/app_router.dart';
 import 'package:bowling_diary/app/theme/app_theme.dart';
-import 'package:bowling_diary/app/theme/color_themes.dart';
 import 'package:bowling_diary/shared/providers/theme_provider.dart';
 
-class BowlingDiaryApp extends ConsumerWidget {
+class BowlingDiaryApp extends ConsumerStatefulWidget {
   const BowlingDiaryApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<BowlingDiaryApp> createState() => _BowlingDiaryAppState();
+}
+
+class _BowlingDiaryAppState extends ConsumerState<BowlingDiaryApp>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangePlatformBrightness() {
+    final brightness =
+        WidgetsBinding.instance.platformDispatcher.platformBrightness;
+    ref.read(platformBrightnessProvider.notifier).state = brightness;
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final router = ref.watch(appRouterProvider);
-    final colorTheme = ref.watch(colorThemeProvider);
-    final palette = ColorThemes.fromTheme(colorTheme);
+    final palette = ref.watch(activePaletteProvider);
     final themeData = AppTheme.fromPalette(palette);
     final themeMode = palette.brightness == Brightness.light
         ? ThemeMode.light
@@ -28,7 +51,7 @@ class BowlingDiaryApp extends ConsumerWidget {
       builder: (context, child) {
         return GestureDetector(
           onTap: () => FocusScope.of(context).unfocus(),
-          child: child,
+          child: child!,
         );
       },
     );

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,13 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bowling_diary/app/router/app_router.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_theme.dart';
+import 'package:bowling_diary/app/theme/color_themes.dart';
 
-/// ProviderScope를 포함한 앱 전체 재시작 위젯
+/// 앱 시작/재시작 전에 팔레트를 동기적으로 세팅
+Future<void> preloadTheme() async {
+  final prefs = await SharedPreferences.getInstance();
+  final idx = prefs.getInt('color_theme_v2');
+  final theme = (idx != null && idx >= 0 && idx < AppColorTheme.values.length)
+      ? AppColorTheme.values[idx]
+      : AppColorTheme.blue;
+  final brightness =
+      WidgetsBinding.instance.platformDispatcher.platformBrightness;
+  AppColors.setPalette(ColorThemes.palette(theme, brightness));
+}
+
 class AppRestarter extends StatefulWidget {
   const AppRestarter({super.key});
 
+  // ignore: library_private_types_in_public_api
   static _AppRestarterState of(BuildContext context) =>
       context.findAncestorStateOfType<_AppRestarterState>()!;
 
@@ -18,8 +32,11 @@ class AppRestarter extends StatefulWidget {
 class _AppRestarterState extends State<AppRestarter> {
   Key _key = UniqueKey();
 
-  /// 호출 시 ProviderScope 포함 전체 재빌드 → 테마 재로드
-  void restart() => setState(() => _key = UniqueKey());
+  /// 팔레트를 먼저 세팅한 뒤 재빌드 — 첫 프레임부터 올바른 색상 적용
+  Future<void> restart() async {
+    await preloadTheme();
+    if (mounted) setState(() => _key = UniqueKey());
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -14,6 +14,10 @@ import 'package:bowling_diary/features/balls/presentation/pages/balls_page.dart'
 import 'package:bowling_diary/features/settings/presentation/pages/settings_page.dart';
 import 'package:bowling_diary/features/admin/presentation/pages/catalog_manage_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_tab_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_camera_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
   final authState = ref.watch(authNotifierProvider);
@@ -86,6 +90,26 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/admin/catalog',
         builder: (context, state) => const CatalogManagePage(),
+      ),
+      // 분석 플로우 — 바텀 네비게이션 없음
+      GoRoute(
+        path: '/analysis/guide',
+        builder: (context, state) => const AnalysisGuidePage(),
+      ),
+      GoRoute(
+        path: '/analysis/camera',
+        builder: (context, state) => const AnalysisCameraPage(),
+      ),
+      GoRoute(
+        path: '/analysis/result',
+        builder: (context, state) {
+          final extra = state.extra as Map<String, dynamic>;
+          return AnalysisResultPage(
+            analysisData: extra['analysisData'] as AnalysisData,
+            videoPath: extra['videoPath'] as String,
+            recordedAt: extra['recordedAt'] as DateTime,
+          );
+        },
       ),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) {

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -80,6 +80,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         },
       ),
       GoRoute(
+        path: '/balls',
+        builder: (context, state) => const BallsPage(),
+      ),
+      GoRoute(
         path: '/admin/catalog',
         builder: (context, state) => const CatalogManagePage(),
       ),
@@ -109,14 +113,6 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: '/analysis',
                 builder: (context, state) => const AnalysisTabPage(),
-              ),
-            ],
-          ),
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/balls',
-                builder: (context, state) => const BallsPage(),
               ),
             ],
           ),
@@ -172,14 +168,9 @@ class ScaffoldWithNavBar extends StatelessWidget {
               label: '분석',
             ),
             BottomNavigationBarItem(
-              icon: Icon(Icons.sports_baseball_outlined),
-              activeIcon: Icon(Icons.sports_baseball),
-              label: '내 볼',
-            ),
-            BottomNavigationBarItem(
               icon: Icon(Icons.person_outline),
               activeIcon: Icon(Icons.person),
-              label: '설정',
+              label: '마이페이지',
             ),
           ],
         ),

--- a/lib/app/theme/app_colors.dart
+++ b/lib/app/theme/app_colors.dart
@@ -4,7 +4,7 @@ import 'color_themes.dart';
 class AppColors {
   AppColors._();
 
-  static ColorPalette _palette = ColorThemes.cream;
+  static ColorPalette _palette = ColorThemes.blueLight;
 
   static void setPalette(ColorPalette palette) {
     _palette = palette;

--- a/lib/app/theme/color_themes.dart
+++ b/lib/app/theme/color_themes.dart
@@ -1,11 +1,6 @@
 import 'package:flutter/material.dart';
 
-enum AppColorTheme {
-  dark,
-  cream,
-  lavender,
-  tossBlue,
-}
+enum AppColorTheme { blue, cream, lavender }
 
 class ColorPalette {
   final Color primary;
@@ -46,58 +41,25 @@ class ColorPalette {
 class ColorThemes {
   ColorThemes._();
 
-  static const dark = ColorPalette(
-    primary: Color(0xFFFF6B35),
-    secondary: Color(0xFF00D9A6),
-    primaryGlow: Color(0x33FF6B35),
-    secondaryGlow: Color(0x3300D9A6),
-    brightness: Brightness.dark,
-    bg: Color(0xFF0D0D0D),
-    surface: Color(0xFF1A1A1A),
-    card: Color(0xFF242424),
-    divider: Color(0xFF2E2E2E),
-    textPrimary: Color(0xFFFFFFFF),
-    textSecondary: Color(0xFFAAAAAA),
-    textHint: Color(0xFF666666),
-    error: Color(0xFFFF4757),
-    success: Color(0xFF2ED573),
-  );
-
-  static const cream = ColorPalette(
-    primary: Color(0xFFFF8A65),
-    secondary: Color(0xFF9CDDCE),
-    primaryGlow: Color(0x33FF8A65),
-    secondaryGlow: Color(0x339CDDCE),
+  // ── 블루 ──────────────────────────────────────────────────
+  static const blueLight = ColorPalette(
+    primary: Color(0xFF3182F6),
+    secondary: Color(0xFF00B4D8),
+    primaryGlow: Color(0x333182F6),
+    secondaryGlow: Color(0x3300B4D8),
     brightness: Brightness.light,
-    bg: Color(0xFFFFFBF5),
-    surface: Color(0xFFFFFDF9),
-    card: Color(0xFFFFF9F0),
-    divider: Color(0xFFEDE4D8),
-    textPrimary: Color(0xFF3D2817),
-    textSecondary: Color(0xFF8B7355),
-    textHint: Color(0xFFBBA88A),
-    error: Color(0xFFE8534A),
-    success: Color(0xFF5CB88A),
+    bg: Color(0xFFF2F6FF),
+    surface: Color(0xFFFFFFFF),
+    card: Color(0xFFFFFFFF),
+    divider: Color(0xFFE2EAF5),
+    textPrimary: Color(0xFF191F28),
+    textSecondary: Color(0xFF6B7684),
+    textHint: Color(0xFFB0BAC8),
+    error: Color(0xFFF04452),
+    success: Color(0xFF05C072),
   );
 
-  static const lavender = ColorPalette(
-    primary: Color(0xFF9B72CF),
-    secondary: Color(0xFFE8A0BF),
-    primaryGlow: Color(0x339B72CF),
-    secondaryGlow: Color(0x33E8A0BF),
-    brightness: Brightness.dark,
-    bg: Color(0xFF13111C),
-    surface: Color(0xFF1C1928),
-    card: Color(0xFF252236),
-    divider: Color(0xFF332F48),
-    textPrimary: Color(0xFFF0EBF8),
-    textSecondary: Color(0xFFA49BBF),
-    textHint: Color(0xFF6B6280),
-    error: Color(0xFFFF6B8A),
-    success: Color(0xFF7EE8B7),
-  );
-
-  static const tossBlue = ColorPalette(
+  static const blueDark = ColorPalette(
     primary: Color(0xFF3182F6),
     secondary: Color(0xFF4DD0E1),
     primaryGlow: Color(0x333182F6),
@@ -114,16 +76,94 @@ class ColorThemes {
     success: Color(0xFF69DB7C),
   );
 
-  static ColorPalette fromTheme(AppColorTheme theme) {
+  // ── 크림 ──────────────────────────────────────────────────
+  static const creamLight = ColorPalette(
+    primary: Color(0xFFFF8A65),
+    secondary: Color(0xFF9CDDCE),
+    primaryGlow: Color(0x33FF8A65),
+    secondaryGlow: Color(0x339CDDCE),
+    brightness: Brightness.light,
+    bg: Color(0xFFFFFBF5),
+    surface: Color(0xFFFFFFFF),
+    card: Color(0xFFFFF9F0),
+    divider: Color(0xFFEDE4D8),
+    textPrimary: Color(0xFF3D2817),
+    textSecondary: Color(0xFF8B7355),
+    textHint: Color(0xFFBBA88A),
+    error: Color(0xFFE8534A),
+    success: Color(0xFF5CB88A),
+  );
+
+  static const creamDark = ColorPalette(
+    primary: Color(0xFFFF8A65),
+    secondary: Color(0xFF9CDDCE),
+    primaryGlow: Color(0x33FF8A65),
+    secondaryGlow: Color(0x339CDDCE),
+    brightness: Brightness.dark,
+    bg: Color(0xFF1A1208),
+    surface: Color(0xFF231A10),
+    card: Color(0xFF2C2215),
+    divider: Color(0xFF3D3020),
+    textPrimary: Color(0xFFF5EFE6),
+    textSecondary: Color(0xFFC4A882),
+    textHint: Color(0xFF8A7060),
+    error: Color(0xFFFF6B5B),
+    success: Color(0xFF6DD9A0),
+  );
+
+  // ── 라벤더 ────────────────────────────────────────────────
+  static const lavenderLight = ColorPalette(
+    primary: Color(0xFF7B61FF),
+    secondary: Color(0xFFE8A0BF),
+    primaryGlow: Color(0x337B61FF),
+    secondaryGlow: Color(0x33E8A0BF),
+    brightness: Brightness.light,
+    bg: Color(0xFFF8F5FF),
+    surface: Color(0xFFFFFFFF),
+    card: Color(0xFFFFFFFF),
+    divider: Color(0xFFE8E0F5),
+    textPrimary: Color(0xFF1A1625),
+    textSecondary: Color(0xFF6B5F80),
+    textHint: Color(0xFFA899C0),
+    error: Color(0xFFE84057),
+    success: Color(0xFF2DB87A),
+  );
+
+  static const lavenderDark = ColorPalette(
+    primary: Color(0xFF9B72CF),
+    secondary: Color(0xFFE8A0BF),
+    primaryGlow: Color(0x339B72CF),
+    secondaryGlow: Color(0x33E8A0BF),
+    brightness: Brightness.dark,
+    bg: Color(0xFF13111C),
+    surface: Color(0xFF1C1928),
+    card: Color(0xFF252236),
+    divider: Color(0xFF332F48),
+    textPrimary: Color(0xFFF0EBF8),
+    textSecondary: Color(0xFFA49BBF),
+    textHint: Color(0xFF6B6280),
+    error: Color(0xFFFF6B8A),
+    success: Color(0xFF7EE8B7),
+  );
+
+  /// 테마 + 디바이스 밝기에 맞는 팔레트 반환
+  static ColorPalette palette(AppColorTheme theme, Brightness brightness) {
+    final isDark = brightness == Brightness.dark;
     switch (theme) {
-      case AppColorTheme.dark:
-        return dark;
+      case AppColorTheme.blue:
+        return isDark ? blueDark : blueLight;
       case AppColorTheme.cream:
-        return cream;
+        return isDark ? creamDark : creamLight;
       case AppColorTheme.lavender:
-        return lavender;
-      case AppColorTheme.tossBlue:
-        return tossBlue;
+        return isDark ? lavenderDark : lavenderLight;
     }
   }
+
+  /// ThemeSelectionPage 미리보기용 — 라이트 팔레트 반환
+  static ColorPalette previewLight(AppColorTheme theme) =>
+      palette(theme, Brightness.light);
+
+  /// ThemeSelectionPage 미리보기용 — 다크 팔레트 반환
+  static ColorPalette previewDark(AppColorTheme theme) =>
+      palette(theme, Brightness.dark);
 }

--- a/lib/features/analysis/data/datasources/analysis_remote_datasource.dart
+++ b/lib/features/analysis/data/datasources/analysis_remote_datasource.dart
@@ -41,4 +41,8 @@ class AnalysisRemoteDataSource {
         .update({'linked_session_id': sessionId})
         .eq('id', analysisId);
   }
+
+  Future<void> delete(String id) async {
+    await _supabase.from('ball_analysis').delete().eq('id', id);
+  }
 }

--- a/lib/features/analysis/data/repositories/analysis_repository_impl.dart
+++ b/lib/features/analysis/data/repositories/analysis_repository_impl.dart
@@ -39,4 +39,7 @@ class AnalysisRepositoryImpl implements AnalysisRepository {
   @override
   Future<void> linkToSession(String analysisId, String sessionId) =>
       _remote.linkToSession(analysisId, sessionId);
+
+  @override
+  Future<void> delete(String id) => _remote.delete(id);
 }

--- a/lib/features/analysis/data/services/camera_recording_service.dart
+++ b/lib/features/analysis/data/services/camera_recording_service.dart
@@ -1,25 +1,15 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 
-/// 녹화 완료 후 반환되는 결과
 class RecordingSession {
   final String videoPath;
-  final List<CameraImage> sampledFrames;
   final int fps;
-  final int sampleInterval;
 
-  const RecordingSession({
-    required this.videoPath,
-    required this.sampledFrames,
-    required this.fps,
-    required this.sampleInterval,
-  });
+  const RecordingSession({required this.videoPath, required this.fps});
 }
 
 class CameraRecordingService {
   CameraController? _controller;
-  final List<CameraImage> _frames = [];
-  int _frameCounter = 0;
   int _fps = 60;
 
   /// 카메라 초기화. 240 → 120 → 60fps 순으로 시도
@@ -36,7 +26,6 @@ class CameraRecordingService {
           back,
           ResolutionPreset.high,
           enableAudio: false,
-          imageFormatGroup: ImageFormatGroup.yuv420,
         );
         await ctrl.initialize();
         await ctrl.getMinExposureOffset();
@@ -59,34 +48,15 @@ class CameraRecordingService {
 
   int get fps => _fps;
 
-  /// 녹화 시작 (프레임 스트림 병행 수집)
   Future<void> startRecording() async {
-    _frames.clear();
-    _frameCounter = 0;
-
-    // 10프레임마다 1개 샘플링
-    await _controller!.startImageStream((image) {
-      _frameCounter++;
-      if (_frameCounter % 10 == 0) {
-        _frames.add(image);
-      }
-    });
     await _controller!.startVideoRecording();
     debugPrint('[Analysis] 녹화 시작');
   }
 
-  /// 녹화 중지 후 RecordingSession 반환
   Future<RecordingSession> stopRecording() async {
     final xfile = await _controller!.stopVideoRecording();
-    await _controller!.stopImageStream();
-
-    debugPrint('[Analysis] 녹화 완료: ${_frames.length}개 프레임 수집');
-    return RecordingSession(
-      videoPath: xfile.path,
-      sampledFrames: List.unmodifiable(_frames),
-      fps: _fps,
-      sampleInterval: 10,
-    );
+    debugPrint('[Analysis] 녹화 완료: ${xfile.path}');
+    return RecordingSession(videoPath: xfile.path, fps: _fps);
   }
 
   void dispose() {

--- a/lib/features/analysis/data/services/camera_recording_service.dart
+++ b/lib/features/analysis/data/services/camera_recording_service.dart
@@ -6,11 +6,13 @@ class RecordingSession {
   final String videoPath;
   final List<CameraImage> sampledFrames;
   final int fps;
+  final int sampleInterval;
 
   const RecordingSession({
     required this.videoPath,
     required this.sampledFrames,
     required this.fps,
+    required this.sampleInterval,
   });
 }
 
@@ -83,6 +85,7 @@ class CameraRecordingService {
       videoPath: xfile.path,
       sampledFrames: List.unmodifiable(_frames),
       fps: _fps,
+      sampleInterval: 10,
     );
   }
 

--- a/lib/features/analysis/data/services/gemini_analysis_service.dart
+++ b/lib/features/analysis/data/services/gemini_analysis_service.dart
@@ -152,19 +152,30 @@ class GeminiAnalysisService {
   }
 
   String _buildPrompt() => '''
-볼링 투구 영상입니다. 다음 기준으로 분석해 JSON만 반환하세요.
+볼링 투구 영상입니다. JSON만 반환하세요.
 
-[구속]
-볼링 레인 파울라인~헤드핀 = 18.29m.
-영상에서 볼링공이 파울라인을 넘는 시점과 헤드핀에 도달하는 시점 사이의 시간으로 speed_kmh를 계산하세요.
-볼을 감지할 수 없으면 0.
+[볼링 레인 규격 — USBC 공식]
+파울라인 ~ 헤드핀(1번 핀) 중심 = 정확히 60피트 = 18.288m
+레인 폭 = 41.5인치 = 1.054m
 
-[RPM]
-볼링공 표면의 텍스처, 로고, 광택 반사 패턴이 영상 전반에 걸쳐 어떻게 변화하는지 분석해 rpm_estimate를 추정하세요.
+[구속 계산 방법]
+1. release_sec: 볼링공이 파울라인을 넘어가는 순간의 영상 타임스탬프 (초)
+2. impact_sec: 볼링공이 헤드핀에 최초 접촉하는 순간의 영상 타임스탬프 (초)
+3. elapsed = impact_sec - release_sec
+4. speed_kmh = (18.288 / elapsed) × 3.6
+※ 볼 감지 불가 시 release_sec, impact_sec 모두 null, speed_kmh = 0
+※ 참고: 일반 볼러 약 19~25 km/h, 상급자 약 25~35 km/h
+
+[RPM 계산 방법]
+release_sec ~ impact_sec 구간에서 볼링공 표면의 텍스처·로고·광택 반사 패턴 변화를 분석해
+회전수를 추정하세요. elapsed 동안의 총 회전수 → RPM = (총 회전수 / elapsed) × 60
 추정 불가 시 null.
+※ 참고: 일반 볼러 약 150~250 RPM, 상급자 약 300~450 RPM
 
 {
-  "speed_kmh": 18.5,
+  "release_sec": 1.2,
+  "impact_sec": 3.8,
+  "speed_kmh": 25.2,
   "rpm_estimate": 280
 }''';
 
@@ -174,9 +185,24 @@ class GeminiAnalysisService {
       final text = json['candidates'][0]['content']['parts'][0]['text'] as String;
       final data = jsonDecode(text) as Map<String, dynamic>;
 
-      final speedKmh = (data['speed_kmh'] as num?)?.toDouble() ?? 0.0;
-      final rpm = data['rpm_estimate'] as int?;
+      final releaseSec = (data['release_sec'] as num?)?.toDouble();
+      final impactSec = (data['impact_sec'] as num?)?.toDouble();
+      double speedKmh = (data['speed_kmh'] as num?)?.toDouble() ?? 0.0;
 
+      // 타임스탬프가 있으면 우리가 직접 재계산 (더 정확)
+      if (releaseSec != null && impactSec != null) {
+        final elapsed = impactSec - releaseSec;
+        if (elapsed > 0.1) {
+          final calculated = (18.288 / elapsed) * 3.6;
+          // 볼링 현실 범위(15~45 km/h) 내면 채택
+          if (calculated >= 15 && calculated <= 45) {
+            speedKmh = calculated;
+          }
+        }
+        debugPrint('[GeminiAnalysis] 릴리즈=${releaseSec}s 임팩트=${impactSec}s elapsed=${(impactSec - releaseSec).toStringAsFixed(2)}s');
+      }
+
+      final rpm = data['rpm_estimate'] as int?;
       debugPrint('[GeminiAnalysis] 결과: ${speedKmh.toStringAsFixed(1)}km/h, RPM=$rpm');
 
       return AnalysisData(

--- a/lib/features/analysis/data/services/gemini_analysis_service.dart
+++ b/lib/features/analysis/data/services/gemini_analysis_service.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:image/image.dart' as img;
+import 'package:bowling_diary/core/constants/app_config.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
+
+class GeminiAnalysisService {
+  static const _apiUrl =
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
+  static const _maxFrames = 15;
+
+  Future<AnalysisData> analyze(
+    List<img.Image> frames,
+    int originalFps, {
+    int sampleFps = 10,
+  }) async {
+    final apiKey = AppConfig.geminiApiKey;
+    if (apiKey.isEmpty) throw Exception('Gemini API 키 없음');
+
+    final selected = _selectKeyFrames(frames);
+    final intervalMs = (1000 / sampleFps).round();
+
+    debugPrint('[GeminiAnalysis] ${selected.length}개 프레임 전송 (간격 ${intervalMs}ms)');
+
+    final parts = <Map<String, dynamic>>[];
+    for (final frame in selected) {
+      final jpeg = img.encodeJpg(img.copyResize(frame, width: 640), quality: 75);
+      parts.add({
+        'inline_data': {
+          'mime_type': 'image/jpeg',
+          'data': base64Encode(jpeg),
+        }
+      });
+    }
+    parts.add({'text': _buildPrompt(selected.length, intervalMs)});
+
+    final response = await http
+        .post(
+          Uri.parse('$_apiUrl?key=$apiKey'),
+          headers: {'Content-Type': 'application/json'},
+          body: jsonEncode({
+            'contents': [
+              {'parts': parts}
+            ],
+            'generationConfig': {'responseMimeType': 'application/json'},
+          }),
+        )
+        .timeout(const Duration(seconds: 90));
+
+    debugPrint('[GeminiAnalysis] 응답 코드: ${response.statusCode}');
+
+    if (response.statusCode == 429) throw const GeminiQuotaExceededException();
+    if (response.statusCode != 200) {
+      throw GeminiApiException('API 오류: ${response.statusCode}');
+    }
+
+    return _parseResponse(response.body, selected.length, originalFps);
+  }
+
+  List<img.Image> _selectKeyFrames(List<img.Image> frames) {
+    if (frames.length <= _maxFrames) return frames;
+    final step = frames.length / _maxFrames;
+    return List.generate(
+      _maxFrames,
+      (i) => frames[(i * step).round().clamp(0, frames.length - 1)],
+    );
+  }
+
+  String _buildPrompt(int frameCount, int intervalMs) => '''
+볼링 투구 영상의 연속 프레임 $frameCount장입니다. 프레임 간격은 ${intervalMs}ms입니다.
+
+아래 기준으로 분석해 JSON을 반환하세요.
+
+[속도]
+볼링 레인 파울라인~헤드핀 = 18.29m.
+볼이 릴리즈된 프레임과 헤드핀 도달 프레임 사이의 경과 시간으로 speed_kmh를 계산하세요.
+볼이 보이지 않으면 0.
+
+[RPM]
+프레임 간 공 표면 텍스처, 로고, 광택 반사 패턴의 변화량을 분석해 rpm_estimate를 추정하세요.
+추정 불가 시 null.
+
+{
+  "speed_kmh": 18.5,
+  "rpm_estimate": 280
+}''';
+
+  AnalysisData _parseResponse(
+      String responseBody, int frameCount, int originalFps) {
+    try {
+      final json = jsonDecode(responseBody);
+      final text =
+          json['candidates'][0]['content']['parts'][0]['text'] as String;
+      final data = jsonDecode(text) as Map<String, dynamic>;
+
+      final speedKmh = (data['speed_kmh'] as num?)?.toDouble() ?? 0.0;
+      final rpm = data['rpm_estimate'] as int?;
+
+      debugPrint(
+          '[GeminiAnalysis] 결과: ${speedKmh.toStringAsFixed(1)}km/h, RPM=$rpm');
+
+      return AnalysisData(
+        speedKmh: double.parse(speedKmh.toStringAsFixed(1)),
+        rpmEstimated: rpm,
+        framesAnalyzed: frameCount,
+        fpsUsed: originalFps,
+      );
+    } catch (e) {
+      debugPrint('[GeminiAnalysis] 파싱 오류: $e');
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frameCount, fpsUsed: originalFps);
+    }
+  }
+}
+
+class GeminiQuotaExceededException implements Exception {
+  const GeminiQuotaExceededException();
+}
+
+class GeminiApiException implements Exception {
+  final String message;
+  const GeminiApiException(this.message);
+}

--- a/lib/features/analysis/data/services/gemini_analysis_service.dart
+++ b/lib/features/analysis/data/services/gemini_analysis_service.dart
@@ -1,84 +1,166 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'package:image/image.dart' as img;
 import 'package:bowling_diary/core/constants/app_config.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
 
 class GeminiAnalysisService {
-  static const _apiUrl =
-      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
-  static const _maxFrames = 15;
+  static const _baseUrl = 'https://generativelanguage.googleapis.com';
 
-  Future<AnalysisData> analyze(
-    List<img.Image> frames,
-    int originalFps, {
-    int sampleFps = 10,
-  }) async {
+  /// 영상 파일을 Gemini File API로 업로드 후 분석
+  Future<AnalysisData> analyzeVideo(String videoPath, int fps) async {
     final apiKey = AppConfig.geminiApiKey;
     if (apiKey.isEmpty) throw Exception('Gemini API 키 없음');
 
-    final selected = _selectKeyFrames(frames);
-    final intervalMs = (1000 / sampleFps).round();
+    final file = File(videoPath);
+    final fileSize = await file.length();
+    final mimeType = videoPath.toLowerCase().endsWith('.mov')
+        ? 'video/quicktime'
+        : 'video/mp4';
 
-    debugPrint('[GeminiAnalysis] ${selected.length}개 프레임 전송 (간격 ${intervalMs}ms)');
+    debugPrint('[GeminiAnalysis] 영상 업로드 시작: ${(fileSize / 1024 / 1024).toStringAsFixed(1)}MB');
 
-    final parts = <Map<String, dynamic>>[];
-    for (final frame in selected) {
-      final jpeg = img.encodeJpg(img.copyResize(frame, width: 640), quality: 75);
-      parts.add({
-        'inline_data': {
-          'mime_type': 'image/jpeg',
-          'data': base64Encode(jpeg),
-        }
-      });
+    String? fileUri;
+    String? fileName;
+
+    try {
+      // 1. 업로드
+      final uploadResult = await _uploadVideo(file, fileSize, mimeType, apiKey);
+      fileUri = uploadResult.$1;
+      fileName = uploadResult.$2;
+
+      // 2. 처리 완료 대기
+      await _waitForProcessing(fileName, apiKey);
+
+      // 3. 분석 요청
+      return await _requestAnalysis(fileUri, mimeType, fps, apiKey);
+    } on GeminiQuotaExceededException {
+      rethrow;
+    } catch (e) {
+      throw GeminiApiException(e.toString());
+    } finally {
+      // 4. 업로드된 파일 삭제 (용량 절약)
+      if (fileName != null) {
+        await _deleteFile(fileName, apiKey);
+      }
     }
-    parts.add({'text': _buildPrompt(selected.length, intervalMs)});
-
-    final response = await http
-        .post(
-          Uri.parse('$_apiUrl?key=$apiKey'),
-          headers: {'Content-Type': 'application/json'},
-          body: jsonEncode({
-            'contents': [
-              {'parts': parts}
-            ],
-            'generationConfig': {'responseMimeType': 'application/json'},
-          }),
-        )
-        .timeout(const Duration(seconds: 90));
-
-    debugPrint('[GeminiAnalysis] 응답 코드: ${response.statusCode}');
-
-    if (response.statusCode == 429) throw const GeminiQuotaExceededException();
-    if (response.statusCode != 200) {
-      throw GeminiApiException('API 오류: ${response.statusCode}');
-    }
-
-    return _parseResponse(response.body, selected.length, originalFps);
   }
 
-  List<img.Image> _selectKeyFrames(List<img.Image> frames) {
-    if (frames.length <= _maxFrames) return frames;
-    final step = frames.length / _maxFrames;
-    return List.generate(
-      _maxFrames,
-      (i) => frames[(i * step).round().clamp(0, frames.length - 1)],
+  /// 리주머블 업로드 → (fileUri, fileName) 반환
+  Future<(String, String)> _uploadVideo(
+    File file,
+    int fileSize,
+    String mimeType,
+    String apiKey,
+  ) async {
+    // Step 1: 업로드 세션 시작
+    final initRes = await http.post(
+      Uri.parse('$_baseUrl/upload/v1beta/files?key=$apiKey'),
+      headers: {
+        'X-Goog-Upload-Protocol': 'resumable',
+        'X-Goog-Upload-Command': 'start',
+        'X-Goog-Upload-Header-Content-Length': fileSize.toString(),
+        'X-Goog-Upload-Header-Content-Type': mimeType,
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({'file': {'display_name': 'bowling_video'}}),
     );
+
+    final uploadUrl = initRes.headers['x-goog-upload-url'];
+    if (uploadUrl == null) {
+      throw Exception('업로드 URL 없음 (${initRes.statusCode})');
+    }
+
+    // Step 2: 파일 업로드
+    final bytes = await file.readAsBytes();
+    final uploadRes = await http.post(
+      Uri.parse(uploadUrl),
+      headers: {
+        'Content-Length': fileSize.toString(),
+        'X-Goog-Upload-Offset': '0',
+        'X-Goog-Upload-Command': 'upload, finalize',
+        'Content-Type': mimeType,
+      },
+      body: bytes,
+    ).timeout(const Duration(minutes: 3));
+
+    if (uploadRes.statusCode != 200) {
+      throw Exception('업로드 실패: ${uploadRes.statusCode}');
+    }
+
+    final data = jsonDecode(uploadRes.body);
+    final fileUri = data['file']['uri'] as String;
+    final fileName = data['file']['name'] as String;
+    debugPrint('[GeminiAnalysis] 업로드 완료: $fileName');
+    return (fileUri, fileName);
   }
 
-  String _buildPrompt(int frameCount, int intervalMs) => '''
-볼링 투구 영상의 연속 프레임 $frameCount장입니다. 프레임 간격은 ${intervalMs}ms입니다.
+  /// 파일 처리 상태가 ACTIVE 될 때까지 폴링
+  Future<void> _waitForProcessing(String fileName, String apiKey) async {
+    for (int i = 0; i < 20; i++) {
+      await Future.delayed(const Duration(seconds: 3));
+      final res = await http.get(
+        Uri.parse('$_baseUrl/v1beta/$fileName?key=$apiKey'),
+      );
+      final state = jsonDecode(res.body)['state'] as String?;
+      debugPrint('[GeminiAnalysis] 처리 상태: $state');
+      if (state == 'ACTIVE') return;
+      if (state == 'FAILED') throw Exception('Gemini 영상 처리 실패');
+    }
+    throw Exception('영상 처리 시간 초과');
+  }
 
-아래 기준으로 분석해 JSON을 반환하세요.
+  /// 분석 요청 → AnalysisData 반환
+  Future<AnalysisData> _requestAnalysis(
+    String fileUri,
+    String mimeType,
+    int fps,
+    String apiKey,
+  ) async {
+    final res = await http.post(
+      Uri.parse('$_baseUrl/v1beta/models/gemini-2.5-flash:generateContent?key=$apiKey'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'contents': [
+          {
+            'parts': [
+              {'file_data': {'mime_type': mimeType, 'file_uri': fileUri}},
+              {'text': _buildPrompt()},
+            ]
+          }
+        ],
+        'generationConfig': {'responseMimeType': 'application/json'},
+      }),
+    ).timeout(const Duration(seconds: 90));
 
-[속도]
+    debugPrint('[GeminiAnalysis] 분석 응답: ${res.statusCode}');
+
+    if (res.statusCode == 429) throw const GeminiQuotaExceededException();
+    if (res.statusCode != 200) throw GeminiApiException('API 오류: ${res.statusCode}');
+
+    return _parseResponse(res.body, fps);
+  }
+
+  Future<void> _deleteFile(String fileName, String apiKey) async {
+    try {
+      await http.delete(
+        Uri.parse('$_baseUrl/v1beta/$fileName?key=$apiKey'),
+      );
+      debugPrint('[GeminiAnalysis] 파일 삭제 완료');
+    } catch (_) {}
+  }
+
+  String _buildPrompt() => '''
+볼링 투구 영상입니다. 다음 기준으로 분석해 JSON만 반환하세요.
+
+[구속]
 볼링 레인 파울라인~헤드핀 = 18.29m.
-볼이 릴리즈된 프레임과 헤드핀 도달 프레임 사이의 경과 시간으로 speed_kmh를 계산하세요.
-볼이 보이지 않으면 0.
+영상에서 볼링공이 파울라인을 넘는 시점과 헤드핀에 도달하는 시점 사이의 시간으로 speed_kmh를 계산하세요.
+볼을 감지할 수 없으면 0.
 
 [RPM]
-프레임 간 공 표면 텍스처, 로고, 광택 반사 패턴의 변화량을 분석해 rpm_estimate를 추정하세요.
+볼링공 표면의 텍스처, 로고, 광택 반사 패턴이 영상 전반에 걸쳐 어떻게 변화하는지 분석해 rpm_estimate를 추정하세요.
 추정 불가 시 null.
 
 {
@@ -86,29 +168,26 @@ class GeminiAnalysisService {
   "rpm_estimate": 280
 }''';
 
-  AnalysisData _parseResponse(
-      String responseBody, int frameCount, int originalFps) {
+  AnalysisData _parseResponse(String body, int fps) {
     try {
-      final json = jsonDecode(responseBody);
-      final text =
-          json['candidates'][0]['content']['parts'][0]['text'] as String;
+      final json = jsonDecode(body);
+      final text = json['candidates'][0]['content']['parts'][0]['text'] as String;
       final data = jsonDecode(text) as Map<String, dynamic>;
 
       final speedKmh = (data['speed_kmh'] as num?)?.toDouble() ?? 0.0;
       final rpm = data['rpm_estimate'] as int?;
 
-      debugPrint(
-          '[GeminiAnalysis] 결과: ${speedKmh.toStringAsFixed(1)}km/h, RPM=$rpm');
+      debugPrint('[GeminiAnalysis] 결과: ${speedKmh.toStringAsFixed(1)}km/h, RPM=$rpm');
 
       return AnalysisData(
         speedKmh: double.parse(speedKmh.toStringAsFixed(1)),
         rpmEstimated: rpm,
-        framesAnalyzed: frameCount,
-        fpsUsed: originalFps,
+        framesAnalyzed: 0,
+        fpsUsed: fps,
       );
     } catch (e) {
-      debugPrint('[GeminiAnalysis] 파싱 오류: $e');
-      return AnalysisData(speedKmh: 0, framesAnalyzed: frameCount, fpsUsed: originalFps);
+      debugPrint('[GeminiAnalysis] 파싱 오류: $e\n$body');
+      return AnalysisData(speedKmh: 0, framesAnalyzed: 0, fpsUsed: fps);
     }
   }
 }
@@ -120,4 +199,6 @@ class GeminiQuotaExceededException implements Exception {
 class GeminiApiException implements Exception {
   final String message;
   const GeminiApiException(this.message);
+  @override
+  String toString() => message;
 }

--- a/lib/features/analysis/data/services/video_analysis_service.dart
+++ b/lib/features/analysis/data/services/video_analysis_service.dart
@@ -77,6 +77,66 @@ class VideoAnalysisService {
     );
   }
 
+  /// 갤러리 영상 프레임(img.Image) 분석 — sampleFps는 추출 시 사용한 fps
+  AnalysisData analyzeImages(
+    List<img.Image> frames,
+    int originalFps, {
+    int sampleFps = 10,
+  }) {
+    debugPrint('[Analysis] 갤러리 분석 시작: ${frames.length}개 프레임, 원본 ${originalFps}fps, 샘플 ${sampleFps}fps');
+
+    if (frames.length < 5) {
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frames.length, fpsUsed: originalFps);
+    }
+
+    final positions = <_BallPosition?>[];
+    img.Image? prevGray;
+
+    for (final frame in frames) {
+      final gray = img.grayscale(frame);
+      if (prevGray != null) {
+        positions.add(_detectBallByMotion(prevGray, gray));
+      } else {
+        positions.add(null);
+      }
+      prevGray = gray;
+    }
+
+    final detected = positions.asMap().entries.where((e) => e.value != null).toList();
+
+    if (detected.length < 3) {
+      debugPrint('[Analysis] 볼 감지 실패 → 속도 0 반환');
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frames.length, fpsUsed: originalFps);
+    }
+
+    final releaseIdx = detected.first.key;
+    final impactIdx = detected.last.key;
+    final sampleInterval = (originalFps / sampleFps).round().clamp(1, 999);
+    final actualFrameCount = (impactIdx - releaseIdx) * sampleInterval;
+    final elapsedSec = actualFrameCount / originalFps;
+
+    if (elapsedSec <= 0) {
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frames.length, fpsUsed: originalFps);
+    }
+
+    final speedKmh = (_laneLength / elapsedSec) * 3.6;
+    debugPrint('[Analysis] 속도: ${speedKmh.toStringAsFixed(1)}km/h');
+
+    final rpm = _estimateRpm(
+      detected.map((e) => e.value!).toList(),
+      originalFps,
+      sampleInterval: sampleInterval,
+    );
+    debugPrint('[Analysis] RPM 추정: $rpm');
+
+    return AnalysisData(
+      speedKmh: double.parse(speedKmh.toStringAsFixed(1)),
+      rpmEstimated: rpm,
+      framesAnalyzed: frames.length,
+      fpsUsed: originalFps,
+    );
+  }
+
   /// CameraImage(YUV420) → 그레이스케일 (Y 채널만 사용)
   img.Image? _toGrayscale(CameraImage frame) {
     try {
@@ -123,7 +183,11 @@ class VideoAnalysisService {
   }
 
   /// 볼의 X 좌표 진동 주기로 RPM 추정
-  int? _estimateRpm(List<_BallPosition> positions, int fps) {
+  int? _estimateRpm(
+    List<_BallPosition> positions,
+    int fps, {
+    int sampleInterval = 10,
+  }) {
     if (positions.length < 4) return null;
 
     int directionChanges = 0;
@@ -135,14 +199,13 @@ class VideoAnalysisService {
       if (dx.abs() > 1) prevDx = dx;
     }
 
-    final sampleFps = fps / 10.0;
-    final durationSec = positions.length / sampleFps;
+    final effectiveFps = fps / sampleInterval;
+    final durationSec = positions.length / effectiveFps;
     if (durationSec <= 0) return null;
 
     final rotationsPerSec = directionChanges / 2.0 / durationSec;
     final rpm = (rotationsPerSec * 60).round();
 
-    // 볼링 RPM 현실 범위 벗어나면 null
     if (rpm < 100 || rpm > 500) return null;
     return rpm;
   }

--- a/lib/features/analysis/data/services/video_frame_extractor_service.dart
+++ b/lib/features/analysis/data/services/video_frame_extractor_service.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_new/ffprobe_kit.dart';
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+import 'package:path_provider/path_provider.dart';
+
+class FrameExtractionResult {
+  final List<img.Image> frames;
+  final int originalFps;
+
+  const FrameExtractionResult({
+    required this.frames,
+    required this.originalFps,
+  });
+}
+
+class VideoFrameExtractorService {
+  static const _sampleFps = 10;
+
+  Future<FrameExtractionResult> extract(String videoPath) async {
+    final originalFps = await _getVideoFps(videoPath);
+
+    final tempDir = await getTemporaryDirectory();
+    final framesDir = Directory(
+      '${tempDir.path}/frames_${DateTime.now().millisecondsSinceEpoch}',
+    );
+    await framesDir.create();
+
+    try {
+      final outputPattern = '${framesDir.path}/frame_%04d.jpg';
+      final session = await FFmpegKit.execute(
+        '-i "$videoPath" -vf fps=$_sampleFps -q:v 2 "$outputPattern"',
+      );
+      final returnCode = await session.getReturnCode();
+
+      if (returnCode == null || !returnCode.isValueSuccess()) {
+        final logs = await session.getLogs();
+        debugPrint('[FrameExtractor] ffmpeg 오류: ${logs.map((l) => l.getMessage()).join('\n')}');
+        throw Exception('프레임 추출 실패 (returnCode: $returnCode)');
+      }
+
+      final frameFiles = framesDir.listSync()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+      final frames = <img.Image>[];
+      for (final file in frameFiles) {
+        if (file is File && file.path.endsWith('.jpg')) {
+          final bytes = await file.readAsBytes();
+          final image = img.decodeImage(bytes);
+          if (image != null) frames.add(image);
+        }
+      }
+
+      debugPrint('[FrameExtractor] 추출 완료: ${frames.length}개 프레임, 원본 ${originalFps}fps');
+      return FrameExtractionResult(frames: frames, originalFps: originalFps);
+    } finally {
+      await framesDir.delete(recursive: true);
+    }
+  }
+
+  Future<int> _getVideoFps(String videoPath) async {
+    try {
+      final session = await FFprobeKit.getMediaInformation(videoPath);
+      final streams = session.getMediaInformation()?.getStreams();
+      if (streams != null) {
+        for (final stream in streams) {
+          if (stream.getType() == 'video') {
+            final fpsStr = stream.getAverageFrameRate(); // "60/1" 형태
+            if (fpsStr != null) {
+              final parts = fpsStr.split('/');
+              if (parts.length == 2) {
+                final num = int.tryParse(parts[0]) ?? 30;
+                final den = int.tryParse(parts[1]) ?? 1;
+                return den > 0 ? (num / den).round() : 30;
+              }
+            }
+          }
+        }
+      }
+    } catch (e) {
+      debugPrint('[FrameExtractor] fps 감지 실패: $e');
+    }
+    return 30;
+  }
+}

--- a/lib/features/analysis/domain/repositories/analysis_repository.dart
+++ b/lib/features/analysis/domain/repositories/analysis_repository.dart
@@ -6,4 +6,5 @@ abstract class AnalysisRepository {
   Future<void> save(AnalysisResultEntity result);
   Future<List<SessionEntity>> getSameDaySessions(String userId, DateTime date);
   Future<void> linkToSession(String analysisId, String sessionId);
+  Future<void> delete(String id);
 }

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -1,10 +1,10 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
-import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/features/analysis/data/services/camera_recording_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_loading_widget.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/camera_guide_overlay.dart';
 
 class AnalysisCameraPage extends StatefulWidget {
@@ -22,6 +22,7 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
   bool _isInitialized = false;
   bool _isRecording = false;
   bool _isAnalyzing = false;
+  String? _analyzingVideoPath;
   String? _error;
 
   @override
@@ -62,6 +63,7 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
 
     try {
       final session = await _cameraService.stopRecording();
+      if (mounted) setState(() => _analyzingVideoPath = session.videoPath);
       final analysisData =
           _analysisService.analyze(session.sampledFrames, session.fps);
 
@@ -109,16 +111,7 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
 
     if (_isAnalyzing) {
       return Scaffold(
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              CircularProgressIndicator(color: AppColors.neonOrange),
-              const SizedBox(height: 24),
-              Text('영상 분석 중...', style: AppTextStyles.bodyLarge),
-            ],
-          ),
-        ),
+        body: AnalysisLoadingWidget(videoPath: _analyzingVideoPath),
       );
     }
 

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -2,7 +2,9 @@ import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/features/analysis/data/services/camera_recording_service.dart';
+import 'package:bowling_diary/features/analysis/data/services/gemini_analysis_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_loading_widget.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/camera_guide_overlay.dart';
@@ -16,7 +18,9 @@ class AnalysisCameraPage extends StatefulWidget {
 
 class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
   final _cameraService = CameraRecordingService();
-  final _analysisService = VideoAnalysisService();
+  final _frameExtractor = VideoFrameExtractorService();
+  final _geminiService = GeminiAnalysisService();
+  final _fallbackService = VideoAnalysisService();
 
   CameraController? _controller;
   bool _isInitialized = false;
@@ -64,8 +68,18 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
     try {
       final session = await _cameraService.stopRecording();
       if (mounted) setState(() => _analyzingVideoPath = session.videoPath);
-      final analysisData =
-          _analysisService.analyze(session.sampledFrames, session.fps);
+
+      final extracted = await _frameExtractor.extract(session.videoPath);
+      AnalysisData analysisData;
+      try {
+        analysisData = await _geminiService.analyze(extracted.frames, extracted.originalFps);
+      } on GeminiQuotaExceededException {
+        debugPrint('[Analysis] Gemini 할당량 초과 → 로컬 분석 fallback');
+        analysisData = _fallbackService.analyzeImages(extracted.frames, extracted.originalFps);
+      } on GeminiApiException catch (e) {
+        debugPrint('[Analysis] Gemini 오류 → fallback: $e');
+        analysisData = _fallbackService.analyzeImages(extracted.frames, extracted.originalFps);
+      }
 
       if (!mounted) return;
       setState(() => _isAnalyzing = false);

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -1,9 +1,11 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/features/analysis/data/services/camera_recording_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/camera_guide_overlay.dart';
 
@@ -17,6 +19,7 @@ class AnalysisCameraPage extends StatefulWidget {
 class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
   final _cameraService = CameraRecordingService();
   final _analysisService = VideoAnalysisService();
+  final _frameExtractor = VideoFrameExtractorService();
 
   CameraController? _controller;
   bool _isInitialized = false;
@@ -51,6 +54,40 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
       await _cameraService.startRecording();
       if (!mounted) return;
       setState(() => _isRecording = true);
+    }
+  }
+
+  Future<void> _pickFromGallery() async {
+    final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
+    if (video == null || !mounted) return;
+
+    setState(() => _isAnalyzing = true);
+    try {
+      final result = await _frameExtractor.extract(video.path);
+      final analysisData = _analysisService.analyzeImages(
+        result.frames,
+        result.originalFps,
+      );
+
+      if (!mounted) return;
+      setState(() => _isAnalyzing = false);
+
+      await Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => AnalysisResultPage(
+            analysisData: analysisData,
+            videoPath: video.path,
+            recordedAt: DateTime.now(),
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isAnalyzing = false;
+        _error = '갤러리 영상 분석 오류: $e';
+      });
     }
   }
 
@@ -157,10 +194,31 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
             right: 40,
             child: Text(
               '${_cameraService.fps}fps',
-              style:
-                  AppTextStyles.bodySmall.copyWith(color: Colors.white70),
+              style: AppTextStyles.bodySmall.copyWith(color: Colors.white70),
             ),
           ),
+          if (!_isRecording)
+            Positioned(
+              bottom: 68,
+              left: 40,
+              child: GestureDetector(
+                onTap: _pickFromGallery,
+                child: Container(
+                  width: 56,
+                  height: 56,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Colors.black45,
+                    border: Border.all(color: Colors.white54, width: 1.5),
+                  ),
+                  child: const Icon(
+                    Icons.photo_library_outlined,
+                    color: Colors.white,
+                    size: 26,
+                  ),
+                ),
+              ),
+            ),
         ],
       ),
     );

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -1,12 +1,12 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/features/analysis/data/services/camera_recording_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/camera_guide_overlay.dart';
 
 class AnalysisCameraPage extends StatefulWidget {
@@ -72,16 +72,12 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
       if (!mounted) return;
       setState(() => _isAnalyzing = false);
 
-      await Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (_) => AnalysisResultPage(
-            analysisData: analysisData,
-            videoPath: video.path,
-            recordedAt: DateTime.now(),
-          ),
-        ),
-      );
+      if (!mounted) return;
+      context.pushReplacement('/analysis/result', extra: {
+        'analysisData': analysisData,
+        'videoPath': video.path,
+        'recordedAt': DateTime.now(),
+      });
     } catch (e) {
       if (!mounted) return;
       setState(() {
@@ -105,16 +101,12 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
       if (!mounted) return;
       setState(() => _isAnalyzing = false);
 
-      await Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (_) => AnalysisResultPage(
-            analysisData: analysisData,
-            videoPath: session.videoPath,
-            recordedAt: DateTime.now(),
-          ),
-        ),
-      );
+      if (!mounted) return;
+      context.pushReplacement('/analysis/result', extra: {
+        'analysisData': analysisData,
+        'videoPath': session.videoPath,
+        'recordedAt': DateTime.now(),
+      });
     } catch (e) {
       if (!mounted) return;
       setState(() {

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -69,15 +69,16 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
       final session = await _cameraService.stopRecording();
       if (mounted) setState(() => _analyzingVideoPath = session.videoPath);
 
-      final extracted = await _frameExtractor.extract(session.videoPath);
       AnalysisData analysisData;
       try {
-        analysisData = await _geminiService.analyze(extracted.frames, extracted.originalFps);
+        analysisData = await _geminiService.analyzeVideo(session.videoPath, session.fps);
       } on GeminiQuotaExceededException {
         debugPrint('[Analysis] Gemini 할당량 초과 → 로컬 분석 fallback');
+        final extracted = await _frameExtractor.extract(session.videoPath);
         analysisData = _fallbackService.analyzeImages(extracted.frames, extracted.originalFps);
       } on GeminiApiException catch (e) {
         debugPrint('[Analysis] Gemini 오류 → fallback: $e');
+        final extracted = await _frameExtractor.extract(session.videoPath);
         analysisData = _fallbackService.analyzeImages(extracted.frames, extracted.originalFps);
       }
 

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -2,10 +2,7 @@ import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/features/analysis/data/services/camera_recording_service.dart';
-import 'package:bowling_diary/features/analysis/data/services/gemini_analysis_service.dart';
-import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
-import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_trim_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_loading_widget.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/camera_guide_overlay.dart';
 
@@ -18,9 +15,6 @@ class AnalysisCameraPage extends StatefulWidget {
 
 class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
   final _cameraService = CameraRecordingService();
-  final _frameExtractor = VideoFrameExtractorService();
-  final _geminiService = GeminiAnalysisService();
-  final _fallbackService = VideoAnalysisService();
 
   CameraController? _controller;
   bool _isInitialized = false;
@@ -67,31 +61,15 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
 
     try {
       final session = await _cameraService.stopRecording();
-      if (mounted) setState(() => _analyzingVideoPath = session.videoPath);
-
-      AnalysisData analysisData;
-      try {
-        analysisData = await _geminiService.analyzeVideo(session.videoPath, session.fps);
-      } on GeminiQuotaExceededException {
-        debugPrint('[Analysis] Gemini 할당량 초과 → 로컬 분석 fallback');
-        final extracted = await _frameExtractor.extract(session.videoPath);
-        analysisData = _fallbackService.analyzeImages(extracted.frames, extracted.originalFps);
-      } on GeminiApiException catch (e) {
-        debugPrint('[Analysis] Gemini 오류 → fallback: $e');
-        final extracted = await _frameExtractor.extract(session.videoPath);
-        analysisData = _fallbackService.analyzeImages(extracted.frames, extracted.originalFps);
-      }
-
       if (!mounted) return;
       setState(() => _isAnalyzing = false);
 
       await Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-          builder: (_) => AnalysisResultPage(
-            analysisData: analysisData,
+          builder: (_) => AnalysisTrimPage(
             videoPath: session.videoPath,
-            recordedAt: DateTime.now(),
+            fps: session.fps,
           ),
         ),
       );

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -1,11 +1,9 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/features/analysis/data/services/camera_recording_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
-import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/camera_guide_overlay.dart';
 
@@ -19,7 +17,6 @@ class AnalysisCameraPage extends StatefulWidget {
 class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
   final _cameraService = CameraRecordingService();
   final _analysisService = VideoAnalysisService();
-  final _frameExtractor = VideoFrameExtractorService();
 
   CameraController? _controller;
   bool _isInitialized = false;
@@ -54,40 +51,6 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
       await _cameraService.startRecording();
       if (!mounted) return;
       setState(() => _isRecording = true);
-    }
-  }
-
-  Future<void> _pickFromGallery() async {
-    final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
-    if (video == null || !mounted) return;
-
-    setState(() => _isAnalyzing = true);
-    try {
-      final result = await _frameExtractor.extract(video.path);
-      final analysisData = _analysisService.analyzeImages(
-        result.frames,
-        result.originalFps,
-      );
-
-      if (!mounted) return;
-      setState(() => _isAnalyzing = false);
-
-      await Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (_) => AnalysisResultPage(
-            analysisData: analysisData,
-            videoPath: video.path,
-            recordedAt: DateTime.now(),
-          ),
-        ),
-      );
-    } catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _isAnalyzing = false;
-        _error = '갤러리 영상 분석 오류: $e';
-      });
     }
   }
 
@@ -197,28 +160,6 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
               style: AppTextStyles.bodySmall.copyWith(color: Colors.white70),
             ),
           ),
-          if (!_isRecording)
-            Positioned(
-              bottom: 68,
-              left: 40,
-              child: GestureDetector(
-                onTap: _pickFromGallery,
-                child: Container(
-                  width: 56,
-                  height: 56,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: Colors.black45,
-                    border: Border.all(color: Colors.white54, width: 1.5),
-                  ),
-                  child: const Icon(
-                    Icons.photo_library_outlined,
-                    color: Colors.white,
-                    size: 26,
-                  ),
-                ),
-              ),
-            ),
         ],
       ),
     );

--- a/lib/features/analysis/presentation/pages/analysis_detail_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_detail_page.dart
@@ -36,7 +36,6 @@ class _AnalysisDetailPageState extends State<AnalysisDetailPage>
       begin: const Offset(0, 0.12),
       end: Offset.zero,
     ).animate(CurvedAnimation(parent: _animCtrl, curve: Curves.easeOut));
-
     _initVideo();
   }
 
@@ -81,15 +80,54 @@ class _AnalysisDetailPageState extends State<AnalysisDetailPage>
     final r = widget.result;
     final hasSpeed = r.speedKmh > 0;
     final hasRpm = r.rpmEstimated != null;
-    final dateStr =
-        DateFormat('yyyy년 MM월 dd일 HH:mm').format(r.recordedAt);
+    final dateStr = DateFormat('yyyy.MM.dd  HH:mm').format(r.recordedAt);
 
     return Scaffold(
       backgroundColor: Colors.black,
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: const BackButton(color: Colors.white),
+        title: Text(
+          dateStr,
+          style: AppTextStyles.bodySmall.copyWith(
+            color: Colors.white60,
+            fontSize: 13,
+          ),
+        ),
+        actions: [
+          if (_videoAvailable)
+            Padding(
+              padding: const EdgeInsets.only(right: 12),
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(20),
+                  border: Border.all(
+                      color: Colors.white.withValues(alpha: 0.18)),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.slow_motion_video,
+                        color: AppColors.neonOrange, size: 13),
+                    const SizedBox(width: 4),
+                    Text('0.25×',
+                        style: AppTextStyles.bodySmall
+                            .copyWith(color: Colors.white60, fontSize: 11)),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
       body: Stack(
         fit: StackFit.expand,
         children: [
-          // 영상 or 어두운 배경
+          // 영상 or 빈 배경
           if (_videoAvailable && _controller != null)
             GestureDetector(
               onTap: _togglePlay,
@@ -106,40 +144,17 @@ class _AnalysisDetailPageState extends State<AnalysisDetailPage>
             Container(
               color: AppColors.darkBg,
               child: Center(
-                child: Icon(
-                  Icons.videocam_off_outlined,
-                  color: AppColors.textHint,
-                  size: 48,
-                ),
+                child: Icon(Icons.videocam_off_outlined,
+                    color: AppColors.textHint, size: 48),
               ),
             ),
-
-          // 상단 그라데이션
-          Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            height: 130,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.black.withValues(alpha: 0.75),
-                    Colors.transparent,
-                  ],
-                ),
-              ),
-            ),
-          ),
 
           // 하단 그라데이션
           Positioned(
             bottom: 0,
             left: 0,
             right: 0,
-            height: 360,
+            height: 380,
             child: DecoratedBox(
               decoration: BoxDecoration(
                 gradient: LinearGradient(
@@ -151,46 +166,6 @@ class _AnalysisDetailPageState extends State<AnalysisDetailPage>
                     Colors.transparent,
                   ],
                 ),
-              ),
-            ),
-          ),
-
-          // 상단바
-          SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Row(
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.arrow_back_ios_new,
-                        color: Colors.white, size: 20),
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                  const Spacer(),
-                  if (_videoAvailable)
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 10, vertical: 5),
-                      decoration: BoxDecoration(
-                        color: Colors.white.withValues(alpha: 0.1),
-                        borderRadius: BorderRadius.circular(20),
-                        border: Border.all(
-                            color: Colors.white.withValues(alpha: 0.18)),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.slow_motion_video,
-                              color: AppColors.neonOrange, size: 13),
-                          const SizedBox(width: 4),
-                          Text('0.25×',
-                              style: AppTextStyles.bodySmall
-                                  .copyWith(color: Colors.white60, fontSize: 11)),
-                        ],
-                      ),
-                    ),
-                  const SizedBox(width: 8),
-                ],
               ),
             ),
           ),
@@ -218,7 +193,7 @@ class _AnalysisDetailPageState extends State<AnalysisDetailPage>
               ),
             ),
 
-          // 하단 통계 패널
+          // 하단 수치 패널
           Positioned(
             bottom: 0,
             left: 0,
@@ -230,20 +205,10 @@ class _AnalysisDetailPageState extends State<AnalysisDetailPage>
                 child: SlideTransition(
                   position: _slideAnim,
                   child: Padding(
-                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 28),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        // 날짜
-                        Text(
-                          dateStr,
-                          style: AppTextStyles.bodySmall.copyWith(
-                            color: Colors.white38,
-                            letterSpacing: 0.3,
-                          ),
-                        ),
-                        const SizedBox(height: 12),
-
                         // 구속
                         Row(
                           crossAxisAlignment: CrossAxisAlignment.end,
@@ -266,14 +231,24 @@ class _AnalysisDetailPageState extends State<AnalysisDetailPage>
                               Padding(
                                 padding: const EdgeInsets.only(
                                     bottom: 8, left: 6),
-                                child: Text(
-                                  'km/h',
-                                  style: TextStyle(
-                                    fontSize: 16,
-                                    color: AppColors.neonOrange
-                                        .withValues(alpha: 0.7),
-                                    fontWeight: FontWeight.w500,
-                                  ),
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.start,
+                                  children: [
+                                    Text('km/h',
+                                        style: TextStyle(
+                                          fontSize: 15,
+                                          color: AppColors.neonOrange
+                                              .withValues(alpha: 0.75),
+                                          fontWeight: FontWeight.w500,
+                                        )),
+                                    Text('구속',
+                                        style: const TextStyle(
+                                          fontSize: 10,
+                                          color: Colors.white38,
+                                          letterSpacing: 1.2,
+                                        )),
+                                  ],
                                 ),
                               ),
                           ],
@@ -284,32 +259,65 @@ class _AnalysisDetailPageState extends State<AnalysisDetailPage>
                           height: 20,
                         ),
 
-                        // RPM + fps
+                        // RPM
                         Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
                           children: [
-                            _InfoChip(
-                              label: 'RPM',
-                              value: hasRpm
-                                  ? '${r.rpmEstimated}'
-                                  : '—',
-                              sub: hasRpm ? '추정값' : null,
-                            ),
-                            const SizedBox(width: 12),
-                            _InfoChip(
-                              label: 'FPS',
-                              value: '${r.fpsUsed}',
-                            ),
-                            if (r.linkedSessionId != null) ...[
-                              const SizedBox(width: 12),
-                              _InfoChip(
-                                label: '세션',
-                                value: '연결됨',
-                                accent: true,
+                            Text(
+                              hasRpm ? '${r.rpmEstimated}' : '—',
+                              style: TextStyle(
+                                fontSize: 44,
+                                fontWeight: FontWeight.w800,
+                                color: hasRpm
+                                    ? Colors.white
+                                    : AppColors.textHint,
+                                height: 1.0,
+                                letterSpacing: -1,
                               ),
-                            ],
+                            ),
+                            if (hasRpm)
+                              Padding(
+                                padding: const EdgeInsets.only(
+                                    bottom: 6, left: 6),
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.start,
+                                  children: [
+                                    const Text('rpm',
+                                        style: TextStyle(
+                                          fontSize: 14,
+                                          color: Colors.white60,
+                                          fontWeight: FontWeight.w500,
+                                        )),
+                                    const Text('RPM 추정값',
+                                        style: TextStyle(
+                                          fontSize: 10,
+                                          color: Colors.white30,
+                                          letterSpacing: 0.5,
+                                        )),
+                                  ],
+                                ),
+                              ),
                           ],
                         ),
-                        const SizedBox(height: 24),
+
+                        if (r.linkedSessionId != null) ...[
+                          const SizedBox(height: 14),
+                          Row(
+                            children: [
+                              Icon(Icons.link_rounded,
+                                  color: AppColors.neonOrange, size: 14),
+                              const SizedBox(width: 6),
+                              Text(
+                                '세션에 연결됨',
+                                style: AppTextStyles.bodySmall.copyWith(
+                                  color: AppColors.neonOrange
+                                      .withValues(alpha: 0.8),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
                       ],
                     ),
                   ),
@@ -317,60 +325,6 @@ class _AnalysisDetailPageState extends State<AnalysisDetailPage>
               ),
             ),
           ),
-        ],
-      ),
-    );
-  }
-}
-
-class _InfoChip extends StatelessWidget {
-  final String label;
-  final String value;
-  final String? sub;
-  final bool accent;
-
-  const _InfoChip({
-    required this.label,
-    required this.value,
-    this.sub,
-    this.accent = false,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.07),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: accent
-              ? AppColors.neonOrange.withValues(alpha: 0.4)
-              : Colors.white.withValues(alpha: 0.1),
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            style: const TextStyle(
-                fontSize: 10, color: Colors.white38, letterSpacing: 1),
-          ),
-          const SizedBox(height: 2),
-          Text(
-            value,
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.w700,
-              color: accent ? AppColors.neonOrange : Colors.white,
-              height: 1.1,
-            ),
-          ),
-          if (sub != null)
-            Text(sub!,
-                style: const TextStyle(
-                    fontSize: 9, color: Colors.white30, letterSpacing: 0.3)),
         ],
       ),
     );

--- a/lib/features/analysis/presentation/pages/analysis_detail_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_detail_page.dart
@@ -1,0 +1,378 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:video_player/video_player.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/domain/entities/analysis_result_entity.dart';
+
+class AnalysisDetailPage extends StatefulWidget {
+  final AnalysisResultEntity result;
+
+  const AnalysisDetailPage({super.key, required this.result});
+
+  @override
+  State<AnalysisDetailPage> createState() => _AnalysisDetailPageState();
+}
+
+class _AnalysisDetailPageState extends State<AnalysisDetailPage>
+    with SingleTickerProviderStateMixin {
+  VideoPlayerController? _controller;
+  bool _videoAvailable = false;
+  late final AnimationController _animCtrl;
+  late final Animation<double> _fadeAnim;
+  late final Animation<Offset> _slideAnim;
+
+  @override
+  void initState() {
+    super.initState();
+    _animCtrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 500),
+    );
+    _fadeAnim = CurvedAnimation(parent: _animCtrl, curve: Curves.easeOut);
+    _slideAnim = Tween<Offset>(
+      begin: const Offset(0, 0.12),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _animCtrl, curve: Curves.easeOut));
+
+    _initVideo();
+  }
+
+  Future<void> _initVideo() async {
+    final path = widget.result.videoLocalPath;
+    if (path == null || !File(path).existsSync()) {
+      _animCtrl.forward();
+      return;
+    }
+    try {
+      final ctrl = VideoPlayerController.file(File(path));
+      await ctrl.initialize();
+      await ctrl.setPlaybackSpeed(0.25);
+      await ctrl.setLooping(true);
+      await ctrl.play();
+      if (!mounted) return;
+      setState(() {
+        _controller = ctrl;
+        _videoAvailable = true;
+      });
+    } catch (_) {}
+    _animCtrl.forward();
+  }
+
+  void _togglePlay() {
+    if (_controller == null) return;
+    _controller!.value.isPlaying
+        ? _controller!.pause()
+        : _controller!.play();
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _animCtrl.dispose();
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final r = widget.result;
+    final hasSpeed = r.speedKmh > 0;
+    final hasRpm = r.rpmEstimated != null;
+    final dateStr =
+        DateFormat('yyyy년 MM월 dd일 HH:mm').format(r.recordedAt);
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          // 영상 or 어두운 배경
+          if (_videoAvailable && _controller != null)
+            GestureDetector(
+              onTap: _togglePlay,
+              child: FittedBox(
+                fit: BoxFit.cover,
+                child: SizedBox(
+                  width: _controller!.value.size.width,
+                  height: _controller!.value.size.height,
+                  child: VideoPlayer(_controller!),
+                ),
+              ),
+            )
+          else
+            Container(
+              color: AppColors.darkBg,
+              child: Center(
+                child: Icon(
+                  Icons.videocam_off_outlined,
+                  color: AppColors.textHint,
+                  size: 48,
+                ),
+              ),
+            ),
+
+          // 상단 그라데이션
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 130,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.75),
+                    Colors.transparent,
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          // 하단 그라데이션
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: 360,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.bottomCenter,
+                  end: Alignment.topCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.95),
+                    Colors.black.withValues(alpha: 0.5),
+                    Colors.transparent,
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          // 상단바
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back_ios_new,
+                        color: Colors.white, size: 20),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                  const Spacer(),
+                  if (_videoAvailable)
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 5),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(
+                            color: Colors.white.withValues(alpha: 0.18)),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.slow_motion_video,
+                              color: AppColors.neonOrange, size: 13),
+                          const SizedBox(width: 4),
+                          Text('0.25×',
+                              style: AppTextStyles.bodySmall
+                                  .copyWith(color: Colors.white60, fontSize: 11)),
+                        ],
+                      ),
+                    ),
+                  const SizedBox(width: 8),
+                ],
+              ),
+            ),
+          ),
+
+          // 일시정지 아이콘
+          if (_videoAvailable &&
+              _controller != null &&
+              !_controller!.value.isPlaying)
+            GestureDetector(
+              onTap: _togglePlay,
+              child: Center(
+                child: Container(
+                  width: 64,
+                  height: 64,
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.45),
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                        color: Colors.white.withValues(alpha: 0.25),
+                        width: 1.5),
+                  ),
+                  child: const Icon(Icons.play_arrow,
+                      color: Colors.white, size: 36),
+                ),
+              ),
+            ),
+
+          // 하단 통계 패널
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: SafeArea(
+              top: false,
+              child: FadeTransition(
+                opacity: _fadeAnim,
+                child: SlideTransition(
+                  position: _slideAnim,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // 날짜
+                        Text(
+                          dateStr,
+                          style: AppTextStyles.bodySmall.copyWith(
+                            color: Colors.white38,
+                            letterSpacing: 0.3,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+
+                        // 구속
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              hasSpeed
+                                  ? r.speedKmh.toStringAsFixed(1)
+                                  : '—',
+                              style: TextStyle(
+                                fontSize: 56,
+                                fontWeight: FontWeight.w800,
+                                color: hasSpeed
+                                    ? AppColors.neonOrange
+                                    : AppColors.textHint,
+                                height: 1.0,
+                                letterSpacing: -1.5,
+                              ),
+                            ),
+                            if (hasSpeed)
+                              Padding(
+                                padding: const EdgeInsets.only(
+                                    bottom: 8, left: 6),
+                                child: Text(
+                                  'km/h',
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color: AppColors.neonOrange
+                                        .withValues(alpha: 0.7),
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+
+                        Divider(
+                          color: Colors.white.withValues(alpha: 0.1),
+                          height: 20,
+                        ),
+
+                        // RPM + fps
+                        Row(
+                          children: [
+                            _InfoChip(
+                              label: 'RPM',
+                              value: hasRpm
+                                  ? '${r.rpmEstimated}'
+                                  : '—',
+                              sub: hasRpm ? '추정값' : null,
+                            ),
+                            const SizedBox(width: 12),
+                            _InfoChip(
+                              label: 'FPS',
+                              value: '${r.fpsUsed}',
+                            ),
+                            if (r.linkedSessionId != null) ...[
+                              const SizedBox(width: 12),
+                              _InfoChip(
+                                label: '세션',
+                                value: '연결됨',
+                                accent: true,
+                              ),
+                            ],
+                          ],
+                        ),
+                        const SizedBox(height: 24),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  final String label;
+  final String value;
+  final String? sub;
+  final bool accent;
+
+  const _InfoChip({
+    required this.label,
+    required this.value,
+    this.sub,
+    this.accent = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: accent
+              ? AppColors.neonOrange.withValues(alpha: 0.4)
+              : Colors.white.withValues(alpha: 0.1),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+                fontSize: 10, color: Colors.white38, letterSpacing: 1),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              color: accent ? AppColors.neonOrange : Colors.white,
+              height: 1.1,
+            ),
+          ),
+          if (sub != null)
+            Text(sub!,
+                style: const TextStyle(
+                    fontSize: 9, color: Colors.white30, letterSpacing: 0.3)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/analysis/presentation/pages/analysis_guide_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_guide_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_camera_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/bowling_pin_character.dart';
 
 class AnalysisGuidePage extends StatefulWidget {
@@ -96,11 +96,7 @@ class _AnalysisGuidePageState extends State<AnalysisGuidePage> {
                           curve: Curves.easeInOut,
                         );
                       } else {
-                        Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(
-                              builder: (_) => const AnalysisCameraPage()),
-                        );
+                        context.pushReplacement('/analysis/camera');
                       }
                     },
                     child: Text(

--- a/lib/features/analysis/presentation/pages/analysis_result_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_result_page.dart
@@ -2,6 +2,7 @@ import 'dart:io' as dart_io;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:uuid/uuid.dart';
 import 'package:video_player/video_player.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
@@ -67,10 +68,11 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
     );
 
     await ref.read(analysisRepositoryProvider).save(entity);
+    ref.invalidate(analysisHistoryProvider);
 
     if (!mounted) return;
     setState(() => _isSaving = false);
-    Navigator.of(context).popUntil((r) => r.isFirst);
+    context.go('/analysis');
   }
 
   Future<void> _onSavePressed() async {

--- a/lib/features/analysis/presentation/pages/analysis_result_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_result_page.dart
@@ -28,13 +28,26 @@ class AnalysisResultPage extends ConsumerStatefulWidget {
   ConsumerState<AnalysisResultPage> createState() => _AnalysisResultPageState();
 }
 
-class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
+class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage>
+    with SingleTickerProviderStateMixin {
   VideoPlayerController? _videoController;
   bool _isSaving = false;
+  late final AnimationController _animCtrl;
+  late final Animation<double> _fadeAnim;
+  late final Animation<Offset> _slideAnim;
 
   @override
   void initState() {
     super.initState();
+    _animCtrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+    _fadeAnim = CurvedAnimation(parent: _animCtrl, curve: Curves.easeOut);
+    _slideAnim = Tween<Offset>(
+      begin: const Offset(0, 0.15),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _animCtrl, curve: Curves.easeOut));
     _initVideo();
   }
 
@@ -46,6 +59,15 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
     await ctrl.play();
     if (!mounted) return;
     setState(() => _videoController = ctrl);
+    _animCtrl.forward();
+  }
+
+  void _togglePlay() {
+    if (_videoController == null) return;
+    _videoController!.value.isPlaying
+        ? _videoController!.pause()
+        : _videoController!.play();
+    setState(() {});
   }
 
   Future<void> _save({String? linkedSessionId}) async {
@@ -86,22 +108,19 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
 
     final picked = await showModalBottomSheet<String?>(
       context: context,
+      backgroundColor: AppColors.darkCard,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
       builder: (_) => _SessionLinkSheet(sessions: sessions),
     );
     if (!mounted) return;
     await _save(linkedSessionId: picked);
   }
 
-  void _togglePlay() {
-    if (_videoController == null) return;
-    _videoController!.value.isPlaying
-        ? _videoController!.pause()
-        : _videoController!.play();
-    setState(() {});
-  }
-
   @override
   void dispose() {
+    _animCtrl.dispose();
     _videoController?.dispose();
     super.dispose();
   }
@@ -109,149 +128,207 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
   @override
   Widget build(BuildContext context) {
     final data = widget.analysisData;
-    final isVideoReady =
+    final isReady =
         _videoController != null && _videoController!.value.isInitialized;
 
     return Scaffold(
       backgroundColor: Colors.black,
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        title: const Text('측정 결과'),
-      ),
-      body: Column(
+      body: Stack(
+        fit: StackFit.expand,
         children: [
-          // 영상 + 오버레이
-          Expanded(
-            child: GestureDetector(
+          // 영상 전체 배경
+          if (isReady)
+            GestureDetector(
               onTap: _togglePlay,
-              child: Stack(
-                fit: StackFit.expand,
+              child: FittedBox(
+                fit: BoxFit.cover,
+                child: SizedBox(
+                  width: _videoController!.value.size.width,
+                  height: _videoController!.value.size.height,
+                  child: VideoPlayer(_videoController!),
+                ),
+              ),
+            )
+          else
+            const Center(
+              child: CircularProgressIndicator(color: Colors.white38),
+            ),
+
+          // 상단 그라데이션 (앱바 영역)
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 120,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.7),
+                    Colors.transparent,
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          // 하단 그라데이션 (결과 영역)
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: 340,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.bottomCenter,
+                  end: Alignment.topCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.92),
+                    Colors.black.withValues(alpha: 0.6),
+                    Colors.transparent,
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          // 상단 바
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Row(
                 children: [
-                  // 영상
-                  if (isVideoReady)
-                    FittedBox(
-                      fit: BoxFit.cover,
-                      child: SizedBox(
-                        width: _videoController!.value.size.width,
-                        height: _videoController!.value.size.height,
-                        child: VideoPlayer(_videoController!),
-                      ),
-                    )
-                  else
-                    const Center(
-                      child: CircularProgressIndicator(),
-                    ),
-
-                  // 하단 그라데이션
-                  Positioned.fill(
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topCenter,
-                          end: Alignment.bottomCenter,
-                          colors: [
-                            Colors.transparent,
-                            Colors.transparent,
-                            Colors.black.withValues(alpha: 0.7),
-                          ],
-                          stops: const [0.0, 0.5, 1.0],
-                        ),
-                      ),
-                    ),
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back_ios_new,
+                        color: Colors.white, size: 20),
+                    onPressed: () => Navigator.of(context).pop(),
                   ),
-
-                  // 재생/일시정지 중앙 아이콘 (일시정지 시만)
-                  if (isVideoReady && !_videoController!.value.isPlaying)
-                    Center(
-                      child: Container(
-                        width: 64,
-                        height: 64,
-                        decoration: BoxDecoration(
-                          color: Colors.black45,
-                          shape: BoxShape.circle,
-                        ),
-                        child: const Icon(Icons.play_arrow,
-                            color: Colors.white, size: 40),
-                      ),
-                    ),
-
+                  const Spacer(),
                   // 슬로우모션 뱃지
-                  Positioned(
-                    top: 12,
-                    right: 16,
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 10, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: Colors.black54,
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Text(
-                        '0.25× 슬로우모션',
-                        style: AppTextStyles.bodySmall
-                            .copyWith(color: Colors.white70),
-                      ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 10, vertical: 5),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.12),
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                          color: Colors.white.withValues(alpha: 0.2)),
                     ),
-                  ),
-
-                  // 구속 · RPM 오버레이 (하단)
-                  Positioned(
-                    left: 16,
-                    right: 16,
-                    bottom: 20,
                     child: Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
-                        _StatOverlayCard(
-                          label: '구속',
-                          value: data.speedKmh > 0
-                              ? data.speedKmh.toStringAsFixed(1)
-                              : '—',
-                          unit: 'km/h',
-                          isMain: true,
-                        ),
-                        const SizedBox(width: 12),
-                        _StatOverlayCard(
-                          label: 'RPM',
-                          value: data.rpmEstimated != null
-                              ? data.rpmEstimated.toString()
-                              : '—',
-                          unit: 'rpm',
-                          isMain: false,
-                          note: '추정값',
-                        ),
+                        Icon(Icons.slow_motion_video,
+                            color: AppColors.neonOrange, size: 14),
+                        const SizedBox(width: 4),
+                        Text('0.25×',
+                            style: AppTextStyles.bodySmall
+                                .copyWith(color: Colors.white70)),
                       ],
                     ),
                   ),
+                  const SizedBox(width: 8),
                 ],
               ),
             ),
           ),
 
-          // 저장 버튼
-          SafeArea(
-            top: false,
-            child: Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-              child: SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColors.neonOrange,
-                    foregroundColor: Colors.black,
-                    padding: const EdgeInsets.symmetric(vertical: 16),
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12)),
+          // 일시정지 아이콘
+          if (isReady && !_videoController!.value.isPlaying)
+            GestureDetector(
+              onTap: _togglePlay,
+              child: Center(
+                child: Container(
+                  width: 72,
+                  height: 72,
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.5),
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                        color: Colors.white.withValues(alpha: 0.3), width: 1.5),
                   ),
-                  onPressed: _isSaving ? null : _onSavePressed,
-                  child: _isSaving
-                      ? const SizedBox(
-                          height: 20,
-                          width: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2))
-                      : Text('저장',
-                          style: AppTextStyles.bodyLarge
-                              .copyWith(fontWeight: FontWeight.bold)),
+                  child: const Icon(Icons.play_arrow,
+                      color: Colors.white, size: 40),
+                ),
+              ),
+            ),
+
+          // 하단 결과 패널
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: SafeArea(
+              top: false,
+              child: FadeTransition(
+                opacity: _fadeAnim,
+                child: SlideTransition(
+                  position: _slideAnim,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // 구속
+                        _StatRow(
+                          label: '구속',
+                          value: data.speedKmh > 0
+                              ? data.speedKmh.toStringAsFixed(1)
+                              : '—',
+                          unit: 'km/h',
+                          highlight: true,
+                        ),
+                        const SizedBox(height: 2),
+                        // 구분선
+                        Divider(
+                          color: Colors.white.withValues(alpha: 0.1),
+                          height: 16,
+                        ),
+                        // RPM
+                        _StatRow(
+                          label: 'RPM',
+                          value: data.rpmEstimated != null
+                              ? data.rpmEstimated.toString()
+                              : '—',
+                          unit: 'rpm',
+                          highlight: false,
+                          badge: '추정값',
+                        ),
+                        const SizedBox(height: 20),
+                        // 저장 버튼
+                        SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.neonOrange,
+                              foregroundColor: Colors.black,
+                              padding:
+                                  const EdgeInsets.symmetric(vertical: 16),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(14),
+                              ),
+                              elevation: 0,
+                            ),
+                            onPressed: _isSaving ? null : _onSavePressed,
+                            child: _isSaving
+                                ? const SizedBox(
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        color: Colors.black54))
+                                : Text(
+                                    '저장하기',
+                                    style: AppTextStyles.bodyLarge.copyWith(
+                                        fontWeight: FontWeight.w700),
+                                  ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               ),
             ),
@@ -262,77 +339,84 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
   }
 }
 
-class _StatOverlayCard extends StatelessWidget {
+class _StatRow extends StatelessWidget {
   final String label;
   final String value;
   final String unit;
-  final bool isMain;
-  final String? note;
+  final bool highlight;
+  final String? badge;
 
-  const _StatOverlayCard({
+  const _StatRow({
     required this.label,
     required this.value,
     required this.unit,
-    required this.isMain,
-    this.note,
+    required this.highlight,
+    this.badge,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        decoration: BoxDecoration(
-          color: Colors.black.withValues(alpha: 0.55),
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: isMain
-                ? AppColors.neonOrange.withValues(alpha: 0.6)
-                : Colors.white24,
-            width: 1,
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        // 숫자
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: highlight ? 52 : 44,
+            fontWeight: FontWeight.w800,
+            color: highlight ? AppColors.neonOrange : Colors.white,
+            height: 1.0,
+            letterSpacing: -1,
           ),
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              label,
-              style:
-                  AppTextStyles.bodySmall.copyWith(color: Colors.white60),
-            ),
-            const SizedBox(height: 2),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                Text(
-                  value,
-                  style: TextStyle(
-                    fontSize: isMain ? 32 : 28,
-                    fontWeight: FontWeight.bold,
-                    color: isMain ? AppColors.neonOrange : Colors.white,
-                    height: 1.1,
-                  ),
-                ),
-                const SizedBox(width: 4),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 4),
-                  child: Text(
-                    unit,
-                    style: AppTextStyles.bodySmall
-                        .copyWith(color: Colors.white60),
-                  ),
-                ),
-              ],
-            ),
-            if (note != null)
+        const SizedBox(width: 6),
+        // 단위 + 라벨
+        Padding(
+          padding: const EdgeInsets.only(bottom: 6),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
               Text(
-                note!,
-                style: AppTextStyles.bodySmall
-                    .copyWith(color: Colors.white38, fontSize: 10),
+                unit,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                  color: highlight
+                      ? AppColors.neonOrange.withValues(alpha: 0.8)
+                      : Colors.white60,
+                ),
               ),
-          ],
+              Text(
+                label,
+                style: const TextStyle(
+                  fontSize: 11,
+                  color: Colors.white38,
+                  letterSpacing: 1.2,
+                ),
+              ),
+            ],
+          ),
         ),
-      ),
+        if (badge != null) ...[
+          const Spacer(),
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(6),
+              border:
+                  Border.all(color: Colors.white.withValues(alpha: 0.15)),
+            ),
+            child: Text(
+              badge!,
+              style: const TextStyle(
+                  fontSize: 10, color: Colors.white38, letterSpacing: 0.5),
+            ),
+          ),
+        ],
+      ],
     );
   }
 }
@@ -345,13 +429,23 @@ class _SessionLinkSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(20),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('오늘 기록에 연결할까요?', style: AppTextStyles.headingSmall),
-            const SizedBox(height: 8),
+            Container(
+              width: 36,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 20),
+              decoration: BoxDecoration(
+                color: AppColors.textHint,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Text('오늘 기록에 연결할까요?',
+                style: AppTextStyles.headingSmall),
+            const SizedBox(height: 6),
             Text(
               '연결하면 해당 세션에서 볼 분석 결과를 확인할 수 있어요.',
               style: AppTextStyles.bodySmall
@@ -359,15 +453,17 @@ class _SessionLinkSheet extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             ...sessions.map((s) => ListTile(
+                  contentPadding: EdgeInsets.zero,
                   title: Text(s.alleyName ?? '볼링장 미입력',
                       style: AppTextStyles.bodyMedium),
                   subtitle: Text('${s.date.month}/${s.date.day}',
                       style: AppTextStyles.bodySmall),
-                  trailing: const Icon(Icons.link),
+                  trailing: Icon(Icons.link, color: AppColors.neonOrange),
                   onTap: () => Navigator.pop(context, s.id),
                 )),
             ListTile(
-              title: Text('연결 없이 독립 저장',
+              contentPadding: EdgeInsets.zero,
+              title: Text('연결 없이 저장',
                   style: AppTextStyles.bodyMedium
                       .copyWith(color: AppColors.textSecondary)),
               onTap: () => Navigator.pop(context, null),

--- a/lib/features/analysis/presentation/pages/analysis_result_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_result_page.dart
@@ -39,19 +39,18 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
   }
 
   Future<void> _initVideo() async {
-    final videoCtrl =
-        VideoPlayerController.file(dart_io.File(widget.videoPath));
-    await videoCtrl.initialize();
-    await videoCtrl.setPlaybackSpeed(0.25);
-    await videoCtrl.setLooping(true);
+    final ctrl = VideoPlayerController.file(dart_io.File(widget.videoPath));
+    await ctrl.initialize();
+    await ctrl.setPlaybackSpeed(0.25);
+    await ctrl.setLooping(true);
+    await ctrl.play();
     if (!mounted) return;
-    setState(() => _videoController = videoCtrl);
+    setState(() => _videoController = ctrl);
   }
 
   Future<void> _save({String? linkedSessionId}) async {
     final auth = ref.read(authNotifierProvider);
     if (auth is! AuthStateAuthenticated) return;
-
     setState(() => _isSaving = true);
 
     final entity = AnalysisResultEntity(
@@ -67,7 +66,6 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
     );
 
     await ref.read(analysisRepositoryProvider).save(entity);
-
     if (!mounted) return;
     setState(() => _isSaving = false);
     Navigator.of(context).popUntil((r) => r.isFirst);
@@ -77,10 +75,8 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
     final auth = ref.read(authNotifierProvider);
     if (auth is! AuthStateAuthenticated) return;
 
-    final sessions = await ref.read(
-      sameDaySessionsProvider(widget.recordedAt).future,
-    );
-
+    final sessions =
+        await ref.read(sameDaySessionsProvider(widget.recordedAt).future);
     if (!mounted) return;
 
     if (sessions.isEmpty) {
@@ -92,9 +88,16 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
       context: context,
       builder: (_) => _SessionLinkSheet(sessions: sessions),
     );
-
     if (!mounted) return;
     await _save(linkedSessionId: picked);
+  }
+
+  void _togglePlay() {
+    if (_videoController == null) return;
+    _videoController!.value.isPlaying
+        ? _videoController!.pause()
+        : _videoController!.play();
+    setState(() {});
   }
 
   @override
@@ -106,145 +109,229 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
   @override
   Widget build(BuildContext context) {
     final data = widget.analysisData;
+    final isVideoReady =
+        _videoController != null && _videoController!.value.isInitialized;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('측정 결과')),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (_videoController != null &&
-                _videoController!.value.isInitialized)
-              Column(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        title: const Text('측정 결과'),
+      ),
+      body: Column(
+        children: [
+          // 영상 + 오버레이
+          Expanded(
+            child: GestureDetector(
+              onTap: _togglePlay,
+              child: Stack(
+                fit: StackFit.expand,
                 children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(12),
-                    child: AspectRatio(
-                      aspectRatio: _videoController!.value.aspectRatio,
-                      child: VideoPlayer(_videoController!),
+                  // 영상
+                  if (isVideoReady)
+                    FittedBox(
+                      fit: BoxFit.cover,
+                      child: SizedBox(
+                        width: _videoController!.value.size.width,
+                        height: _videoController!.value.size.height,
+                        child: VideoPlayer(_videoController!),
+                      ),
+                    )
+                  else
+                    const Center(
+                      child: CircularProgressIndicator(),
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      IconButton(
-                        onPressed: () {
-                          _videoController!.value.isPlaying
-                              ? _videoController!.pause()
-                              : _videoController!.play();
-                          setState(() {});
-                        },
-                        icon: Icon(
-                          _videoController!.value.isPlaying
-                              ? Icons.pause
-                              : Icons.play_arrow,
-                          color: AppColors.neonOrange,
+
+                  // 하단 그라데이션
+                  Positioned.fill(
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [
+                            Colors.transparent,
+                            Colors.transparent,
+                            Colors.black.withValues(alpha: 0.7),
+                          ],
+                          stops: const [0.0, 0.5, 1.0],
                         ),
                       ),
-                      Text('0.25× 슬로우모션',
-                          style: AppTextStyles.bodySmall
-                              .copyWith(color: AppColors.textSecondary)),
-                    ],
+                    ),
                   ),
-                  const SizedBox(height: 24),
+
+                  // 재생/일시정지 중앙 아이콘 (일시정지 시만)
+                  if (isVideoReady && !_videoController!.value.isPlaying)
+                    Center(
+                      child: Container(
+                        width: 64,
+                        height: 64,
+                        decoration: BoxDecoration(
+                          color: Colors.black45,
+                          shape: BoxShape.circle,
+                        ),
+                        child: const Icon(Icons.play_arrow,
+                            color: Colors.white, size: 40),
+                      ),
+                    ),
+
+                  // 슬로우모션 뱃지
+                  Positioned(
+                    top: 12,
+                    right: 16,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.black54,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        '0.25× 슬로우모션',
+                        style: AppTextStyles.bodySmall
+                            .copyWith(color: Colors.white70),
+                      ),
+                    ),
+                  ),
+
+                  // 구속 · RPM 오버레이 (하단)
+                  Positioned(
+                    left: 16,
+                    right: 16,
+                    bottom: 20,
+                    child: Row(
+                      children: [
+                        _StatOverlayCard(
+                          label: '구속',
+                          value: data.speedKmh > 0
+                              ? data.speedKmh.toStringAsFixed(1)
+                              : '—',
+                          unit: 'km/h',
+                          isMain: true,
+                        ),
+                        const SizedBox(width: 12),
+                        _StatOverlayCard(
+                          label: 'RPM',
+                          value: data.rpmEstimated != null
+                              ? data.rpmEstimated.toString()
+                              : '—',
+                          unit: 'rpm',
+                          isMain: false,
+                          note: '추정값',
+                        ),
+                      ],
+                    ),
+                  ),
                 ],
-              )
-            else
-              const Center(child: CircularProgressIndicator()),
-            _ResultTile(
-              label: '구속',
-              value: data.speedKmh > 0
-                  ? '${data.speedKmh.toStringAsFixed(1)} km/h'
-                  : '측정 불가',
-              isMain: true,
-            ),
-            const SizedBox(height: 12),
-            _ResultTile(
-              label: 'RPM (추정값)',
-              value: data.rpmEstimated != null
-                  ? '${data.rpmEstimated} RPM'
-                  : '측정 불가',
-              isMain: false,
-              note: 'RPM은 후방 촬영 특성상 추정값입니다',
-            ),
-            const SizedBox(height: 8),
-            Text(
-                '분석 프레임: ${data.framesAnalyzed}개 / ${data.fpsUsed}fps',
-                style: AppTextStyles.bodySmall
-                    .copyWith(color: AppColors.textHint)),
-            const SizedBox(height: 32),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.neonOrange,
-                  foregroundColor: Colors.black,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12)),
-                ),
-                onPressed: _isSaving ? null : _onSavePressed,
-                child: _isSaving
-                    ? const SizedBox(
-                        height: 20,
-                        width: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2))
-                    : Text('저장',
-                        style: AppTextStyles.bodyLarge
-                            .copyWith(fontWeight: FontWeight.bold)),
               ),
             ),
-          ],
-        ),
+          ),
+
+          // 저장 버튼
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              child: SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.neonOrange,
+                    foregroundColor: Colors.black,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12)),
+                  ),
+                  onPressed: _isSaving ? null : _onSavePressed,
+                  child: _isSaving
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2))
+                      : Text('저장',
+                          style: AppTextStyles.bodyLarge
+                              .copyWith(fontWeight: FontWeight.bold)),
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
 }
 
-class _ResultTile extends StatelessWidget {
+class _StatOverlayCard extends StatelessWidget {
   final String label;
   final String value;
+  final String unit;
   final bool isMain;
   final String? note;
 
-  const _ResultTile(
-      {required this.label,
-      required this.value,
-      required this.isMain,
-      this.note});
+  const _StatOverlayCard({
+    required this.label,
+    required this.value,
+    required this.unit,
+    required this.isMain,
+    this.note,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppColors.darkCard,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(label,
-              style: AppTextStyles.bodySmall
-                  .copyWith(color: AppColors.textSecondary)),
-          const SizedBox(height: 4),
-          Text(
-            value,
-            style: isMain
-                ? AppTextStyles.headingLarge
-                    .copyWith(color: AppColors.neonOrange)
-                : AppTextStyles.headingSmall
-                    .copyWith(color: AppColors.textPrimary),
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.55),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: isMain
+                ? AppColors.neonOrange.withValues(alpha: 0.6)
+                : Colors.white24,
+            width: 1,
           ),
-          if (note != null) ...[
-            const SizedBox(height: 4),
-            Text(note!,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              label,
+              style:
+                  AppTextStyles.bodySmall.copyWith(color: Colors.white60),
+            ),
+            const SizedBox(height: 2),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  value,
+                  style: TextStyle(
+                    fontSize: isMain ? 32 : 28,
+                    fontWeight: FontWeight.bold,
+                    color: isMain ? AppColors.neonOrange : Colors.white,
+                    height: 1.1,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(
+                    unit,
+                    style: AppTextStyles.bodySmall
+                        .copyWith(color: Colors.white60),
+                  ),
+                ),
+              ],
+            ),
+            if (note != null)
+              Text(
+                note!,
                 style: AppTextStyles.bodySmall
-                    .copyWith(color: AppColors.textHint)),
+                    .copyWith(color: Colors.white38, fontSize: 10),
+              ),
           ],
-        ],
+        ),
       ),
     );
   }
@@ -265,9 +352,11 @@ class _SessionLinkSheet extends StatelessWidget {
           children: [
             Text('오늘 기록에 연결할까요?', style: AppTextStyles.headingSmall),
             const SizedBox(height: 8),
-            Text('연결하면 해당 세션에서 볼 분석 결과를 확인할 수 있어요.',
-                style: AppTextStyles.bodySmall
-                    .copyWith(color: AppColors.textSecondary)),
+            Text(
+              '연결하면 해당 세션에서 볼 분석 결과를 확인할 수 있어요.',
+              style: AppTextStyles.bodySmall
+                  .copyWith(color: AppColors.textSecondary),
+            ),
             const SizedBox(height: 16),
             ...sessions.map((s) => ListTile(
                   title: Text(s.alleyName ?? '볼링장 미입력',

--- a/lib/features/analysis/presentation/pages/analysis_selection_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_selection_page.dart
@@ -6,6 +6,7 @@ import 'package:bowling_diary/features/analysis/data/services/video_analysis_ser
 import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_loading_widget.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/bowling_pin_character.dart';
 
 class AnalysisSelectionPage extends StatefulWidget {
@@ -19,12 +20,16 @@ class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
   final _frameExtractor = VideoFrameExtractorService();
   final _analysisService = VideoAnalysisService();
   bool _isAnalyzing = false;
+  String? _analyzingVideoPath;
 
   Future<void> _pickFromGallery() async {
     final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
     if (video == null || !mounted) return;
 
-    setState(() => _isAnalyzing = true);
+    setState(() {
+      _isAnalyzing = true;
+      _analyzingVideoPath = video.path;
+    });
     try {
       final result = await _frameExtractor.extract(video.path);
       final analysisData = _analysisService.analyzeImages(
@@ -66,16 +71,7 @@ class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
     return Scaffold(
       appBar: AppBar(title: const Text('볼 분석')),
       body: _isAnalyzing
-          ? Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  CircularProgressIndicator(color: AppColors.neonOrange),
-                  const SizedBox(height: 24),
-                  Text('영상 분석 중...', style: AppTextStyles.bodyLarge),
-                ],
-              ),
-            )
+          ? AnalysisLoadingWidget(videoPath: _analyzingVideoPath)
           : Padding(
               padding: const EdgeInsets.symmetric(horizontal: 32),
               child: Column(

--- a/lib/features/analysis/presentation/pages/analysis_selection_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_selection_page.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/widgets/bowling_pin_character.dart';
+
+class AnalysisSelectionPage extends StatefulWidget {
+  const AnalysisSelectionPage({super.key});
+
+  @override
+  State<AnalysisSelectionPage> createState() => _AnalysisSelectionPageState();
+}
+
+class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
+  final _frameExtractor = VideoFrameExtractorService();
+  final _analysisService = VideoAnalysisService();
+  bool _isAnalyzing = false;
+
+  Future<void> _pickFromGallery() async {
+    final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
+    if (video == null || !mounted) return;
+
+    setState(() => _isAnalyzing = true);
+    try {
+      final result = await _frameExtractor.extract(video.path);
+      final analysisData = _analysisService.analyzeImages(
+        result.frames,
+        result.originalFps,
+      );
+
+      if (!mounted) return;
+      setState(() => _isAnalyzing = false);
+
+      await Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => AnalysisResultPage(
+            analysisData: analysisData,
+            videoPath: video.path,
+            recordedAt: DateTime.now(),
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isAnalyzing = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('영상 분석 실패: $e')),
+      );
+    }
+  }
+
+  void _goToRecord() {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const AnalysisGuidePage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('볼 분석')),
+      body: _isAnalyzing
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  CircularProgressIndicator(color: AppColors.neonOrange),
+                  const SizedBox(height: 24),
+                  Text('영상 분석 중...', style: AppTextStyles.bodyLarge),
+                ],
+              ),
+            )
+          : Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Column(
+                children: [
+                  const Spacer(),
+                  const BowlingPinCharacter(emotion: 'normal'),
+                  const SizedBox(height: 32),
+                  Text(
+                    '어떻게 분석할까요?',
+                    style: AppTextStyles.headingMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    '투구 영상을 직접 촬영하거나\n갤러리에서 불러와 분석해보세요',
+                    style: AppTextStyles.bodyMedium
+                        .copyWith(color: AppColors.textSecondary),
+                    textAlign: TextAlign.center,
+                  ),
+                  const Spacer(),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton.icon(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.neonOrange,
+                        foregroundColor: Colors.black,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      onPressed: _goToRecord,
+                      icon: const Icon(Icons.videocam),
+                      label: Text(
+                        '즉시 촬영하기',
+                        style: AppTextStyles.bodyLarge
+                            .copyWith(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.neonOrange,
+                        side: BorderSide(color: AppColors.neonOrange),
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      onPressed: _pickFromGallery,
+                      icon: const Icon(Icons.photo_library_outlined),
+                      label: Text(
+                        '갤러리에서 가져오기',
+                        style: AppTextStyles.bodyLarge
+                            .copyWith(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 40),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/lib/features/analysis/presentation/pages/analysis_selection_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_selection_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/data/services/gemini_analysis_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
@@ -18,7 +19,8 @@ class AnalysisSelectionPage extends StatefulWidget {
 
 class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
   final _frameExtractor = VideoFrameExtractorService();
-  final _analysisService = VideoAnalysisService();
+  final _geminiService = GeminiAnalysisService();
+  final _fallbackService = VideoAnalysisService();
   bool _isAnalyzing = false;
   String? _analyzingVideoPath;
 
@@ -32,10 +34,7 @@ class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
     });
     try {
       final result = await _frameExtractor.extract(video.path);
-      final analysisData = _analysisService.analyzeImages(
-        result.frames,
-        result.originalFps,
-      );
+      final analysisData = await _analyzeWithFallback(result.frames, result.originalFps);
 
       if (!mounted) return;
       setState(() => _isAnalyzing = false);
@@ -56,6 +55,22 @@ class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('영상 분석 실패: $e')),
       );
+    }
+  }
+
+  Future<AnalysisData> _analyzeWithFallback(
+      List<dynamic> frames, int originalFps) async {
+    try {
+      return await _geminiService.analyze(
+        frames.cast(),
+        originalFps,
+      );
+    } on GeminiQuotaExceededException {
+      debugPrint('[Analysis] Gemini 할당량 초과 → 로컬 분석으로 fallback');
+      return _fallbackService.analyzeImages(frames.cast(), originalFps);
+    } on GeminiApiException catch (e) {
+      debugPrint('[Analysis] Gemini 오류 → fallback: $e');
+      return _fallbackService.analyzeImages(frames.cast(), originalFps);
     }
   }
 

--- a/lib/features/analysis/presentation/pages/analysis_selection_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_selection_page.dart
@@ -33,8 +33,7 @@ class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
       _analyzingVideoPath = video.path;
     });
     try {
-      final result = await _frameExtractor.extract(video.path);
-      final analysisData = await _analyzeWithFallback(result.frames, result.originalFps);
+      final analysisData = await _analyzeWithFallback(video.path, 60);
 
       if (!mounted) return;
       setState(() => _isAnalyzing = false);
@@ -58,19 +57,17 @@ class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
     }
   }
 
-  Future<AnalysisData> _analyzeWithFallback(
-      List<dynamic> frames, int originalFps) async {
+  Future<AnalysisData> _analyzeWithFallback(String videoPath, int fps) async {
     try {
-      return await _geminiService.analyze(
-        frames.cast(),
-        originalFps,
-      );
+      return await _geminiService.analyzeVideo(videoPath, fps);
     } on GeminiQuotaExceededException {
-      debugPrint('[Analysis] Gemini 할당량 초과 → 로컬 분석으로 fallback');
-      return _fallbackService.analyzeImages(frames.cast(), originalFps);
+      debugPrint('[Analysis] Gemini 할당량 초과 → 로컬 분석 fallback');
+      final result = await _frameExtractor.extract(videoPath);
+      return _fallbackService.analyzeImages(result.frames, result.originalFps);
     } on GeminiApiException catch (e) {
       debugPrint('[Analysis] Gemini 오류 → fallback: $e');
-      return _fallbackService.analyzeImages(frames.cast(), originalFps);
+      final result = await _frameExtractor.extract(videoPath);
+      return _fallbackService.analyzeImages(result.frames, result.originalFps);
     }
   }
 

--- a/lib/features/analysis/presentation/pages/analysis_selection_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_selection_page.dart
@@ -2,76 +2,26 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
-import 'package:bowling_diary/features/analysis/data/services/gemini_analysis_service.dart';
-import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
-import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
-import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_loading_widget.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_trim_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/bowling_pin_character.dart';
 
-class AnalysisSelectionPage extends StatefulWidget {
+class AnalysisSelectionPage extends StatelessWidget {
   const AnalysisSelectionPage({super.key});
 
-  @override
-  State<AnalysisSelectionPage> createState() => _AnalysisSelectionPageState();
-}
-
-class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
-  final _frameExtractor = VideoFrameExtractorService();
-  final _geminiService = GeminiAnalysisService();
-  final _fallbackService = VideoAnalysisService();
-  bool _isAnalyzing = false;
-  String? _analyzingVideoPath;
-
-  Future<void> _pickFromGallery() async {
+  Future<void> _pickFromGallery(BuildContext context) async {
     final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
-    if (video == null || !mounted) return;
+    if (video == null || !context.mounted) return;
 
-    setState(() {
-      _isAnalyzing = true;
-      _analyzingVideoPath = video.path;
-    });
-    try {
-      final analysisData = await _analyzeWithFallback(video.path, 60);
-
-      if (!mounted) return;
-      setState(() => _isAnalyzing = false);
-
-      await Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (_) => AnalysisResultPage(
-            analysisData: analysisData,
-            videoPath: video.path,
-            recordedAt: DateTime.now(),
-          ),
-        ),
-      );
-    } catch (e) {
-      if (!mounted) return;
-      setState(() => _isAnalyzing = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('영상 분석 실패: $e')),
-      );
-    }
+    await Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => AnalysisTrimPage(videoPath: video.path, fps: 60),
+      ),
+    );
   }
 
-  Future<AnalysisData> _analyzeWithFallback(String videoPath, int fps) async {
-    try {
-      return await _geminiService.analyzeVideo(videoPath, fps);
-    } on GeminiQuotaExceededException {
-      debugPrint('[Analysis] Gemini 할당량 초과 → 로컬 분석 fallback');
-      final result = await _frameExtractor.extract(videoPath);
-      return _fallbackService.analyzeImages(result.frames, result.originalFps);
-    } on GeminiApiException catch (e) {
-      debugPrint('[Analysis] Gemini 오류 → fallback: $e');
-      final result = await _frameExtractor.extract(videoPath);
-      return _fallbackService.analyzeImages(result.frames, result.originalFps);
-    }
-  }
-
-  void _goToRecord() {
+  void _goToRecord(BuildContext context) {
     Navigator.pushReplacement(
       context,
       MaterialPageRoute(builder: (_) => const AnalysisGuidePage()),
@@ -82,73 +32,71 @@ class _AnalysisSelectionPageState extends State<AnalysisSelectionPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('볼 분석')),
-      body: _isAnalyzing
-          ? AnalysisLoadingWidget(videoPath: _analyzingVideoPath)
-          : Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 32),
-              child: Column(
-                children: [
-                  const Spacer(),
-                  const BowlingPinCharacter(emotion: 'normal'),
-                  const SizedBox(height: 32),
-                  Text(
-                    '어떻게 분석할까요?',
-                    style: AppTextStyles.headingMedium,
-                    textAlign: TextAlign.center,
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          children: [
+            const Spacer(),
+            const BowlingPinCharacter(emotion: 'normal'),
+            const SizedBox(height: 32),
+            Text(
+              '어떻게 분석할까요?',
+              style: AppTextStyles.headingMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              '투구 영상을 직접 촬영하거나\n갤러리에서 불러와 분석해보세요',
+              style: AppTextStyles.bodyMedium
+                  .copyWith(color: AppColors.textSecondary),
+              textAlign: TextAlign.center,
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.neonOrange,
+                  foregroundColor: Colors.black,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
                   ),
-                  const SizedBox(height: 12),
-                  Text(
-                    '투구 영상을 직접 촬영하거나\n갤러리에서 불러와 분석해보세요',
-                    style: AppTextStyles.bodyMedium
-                        .copyWith(color: AppColors.textSecondary),
-                    textAlign: TextAlign.center,
-                  ),
-                  const Spacer(),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton.icon(
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: AppColors.neonOrange,
-                        foregroundColor: Colors.black,
-                        padding: const EdgeInsets.symmetric(vertical: 16),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      onPressed: _goToRecord,
-                      icon: const Icon(Icons.videocam),
-                      label: Text(
-                        '즉시 촬영하기',
-                        style: AppTextStyles.bodyLarge
-                            .copyWith(fontWeight: FontWeight.bold),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: OutlinedButton.icon(
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: AppColors.neonOrange,
-                        side: BorderSide(color: AppColors.neonOrange),
-                        padding: const EdgeInsets.symmetric(vertical: 16),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      onPressed: _pickFromGallery,
-                      icon: const Icon(Icons.photo_library_outlined),
-                      label: Text(
-                        '갤러리에서 가져오기',
-                        style: AppTextStyles.bodyLarge
-                            .copyWith(fontWeight: FontWeight.bold),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 40),
-                ],
+                ),
+                onPressed: () => _goToRecord(context),
+                icon: const Icon(Icons.videocam),
+                label: Text(
+                  '즉시 촬영하기',
+                  style: AppTextStyles.bodyLarge
+                      .copyWith(fontWeight: FontWeight.bold),
+                ),
               ),
             ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: AppColors.neonOrange,
+                  side: BorderSide(color: AppColors.neonOrange),
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                onPressed: () => _pickFromGallery(context),
+                icon: const Icon(Icons.photo_library_outlined),
+                label: Text(
+                  '갤러리에서 가져오기',
+                  style: AppTextStyles.bodyLarge
+                      .copyWith(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
+            const SizedBox(height: 40),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -1,153 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
-import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
-import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_selection_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/providers/analysis_provider.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_history_card.dart';
 import 'package:bowling_diary/shared/widgets/loading_widget.dart';
 
-class AnalysisTabPage extends ConsumerStatefulWidget {
+class AnalysisTabPage extends ConsumerWidget {
   const AnalysisTabPage({super.key});
 
   @override
-  ConsumerState<AnalysisTabPage> createState() => _AnalysisTabPageState();
-}
-
-class _AnalysisTabPageState extends ConsumerState<AnalysisTabPage> {
-  final _frameExtractor = VideoFrameExtractorService();
-  final _analysisService = VideoAnalysisService();
-  bool _isAnalyzing = false;
-
-  void _onFabTapped() {
-    showModalBottomSheet(
-      context: context,
-      backgroundColor: AppColors.darkCard,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      builder: (_) => SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                width: 40,
-                height: 4,
-                margin: const EdgeInsets.only(bottom: 20),
-                decoration: BoxDecoration(
-                  color: AppColors.textHint,
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              ListTile(
-                leading: Container(
-                  width: 44,
-                  height: 44,
-                  decoration: BoxDecoration(
-                    color: AppColors.neonOrange.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Icon(Icons.videocam, color: AppColors.neonOrange),
-                ),
-                title: Text('즉시 촬영하기', style: AppTextStyles.bodyLarge),
-                subtitle: Text('카메라로 투구 영상을 녹화합니다',
-                    style: AppTextStyles.bodySmall.copyWith(color: AppColors.textSecondary)),
-                onTap: () {
-                  Navigator.pop(context);
-                  _goToRecord();
-                },
-              ),
-              ListTile(
-                leading: Container(
-                  width: 44,
-                  height: 44,
-                  decoration: BoxDecoration(
-                    color: AppColors.neonOrange.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Icon(Icons.photo_library_outlined, color: AppColors.neonOrange),
-                ),
-                title: Text('갤러리에서 가져오기', style: AppTextStyles.bodyLarge),
-                subtitle: Text('저장된 영상으로 분석합니다',
-                    style: AppTextStyles.bodySmall.copyWith(color: AppColors.textSecondary)),
-                onTap: () {
-                  Navigator.pop(context);
-                  _pickFromGallery();
-                },
-              ),
-              const SizedBox(height: 8),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  void _goToRecord() {
-    Navigator.of(context, rootNavigator: true)
-        .push(MaterialPageRoute(builder: (_) => const AnalysisGuidePage()))
-        .then((_) => ref.invalidate(analysisHistoryProvider));
-  }
-
-  Future<void> _pickFromGallery() async {
-    final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
-    if (video == null || !mounted) return;
-
-    setState(() => _isAnalyzing = true);
-    try {
-      final result = await _frameExtractor.extract(video.path);
-      final analysisData = _analysisService.analyzeImages(
-        result.frames,
-        result.originalFps,
-      );
-
-      if (!mounted) return;
-      setState(() => _isAnalyzing = false);
-
-      await Navigator.of(context, rootNavigator: true).push(
-        MaterialPageRoute(
-          builder: (_) => AnalysisResultPage(
-            analysisData: analysisData,
-            videoPath: video.path,
-            recordedAt: DateTime.now(),
-          ),
-        ),
-      );
-      ref.invalidate(analysisHistoryProvider);
-    } catch (e) {
-      if (!mounted) return;
-      setState(() => _isAnalyzing = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('영상 분석 실패: $e')),
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final history = ref.watch(analysisHistoryProvider);
-
-    if (_isAnalyzing) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('볼 분석')),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              CircularProgressIndicator(color: AppColors.neonOrange),
-              const SizedBox(height: 24),
-              Text('영상 분석 중...', style: AppTextStyles.bodyLarge),
-            ],
-          ),
-        ),
-      );
-    }
 
     return Scaffold(
       appBar: AppBar(title: const Text('볼 분석')),
@@ -181,7 +46,9 @@ class _AnalysisTabPageState extends ConsumerState<AnalysisTabPage> {
       ),
       floatingActionButton: FloatingActionButton(
         backgroundColor: AppColors.neonOrange,
-        onPressed: _onFabTapped,
+        onPressed: () => Navigator.of(context, rootNavigator: true)
+            .push(MaterialPageRoute(builder: (_) => const AnalysisSelectionPage()))
+            .then((_) => ref.invalidate(analysisHistoryProvider)),
         child: const Icon(Icons.add, color: Colors.black),
       ),
     );

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -8,17 +8,39 @@ import 'package:bowling_diary/features/analysis/presentation/providers/analysis_
 import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_history_card.dart';
 import 'package:bowling_diary/shared/widgets/loading_widget.dart';
 
-class AnalysisTabPage extends ConsumerWidget {
+class AnalysisTabPage extends ConsumerStatefulWidget {
   const AnalysisTabPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<AnalysisTabPage> createState() => _AnalysisTabPageState();
+}
+
+class _AnalysisTabPageState extends ConsumerState<AnalysisTabPage> {
+  // 로컬에서 먼저 제거한 ID 목록 — Supabase 응답 전까지 화면에서 숨김
+  final Set<String> _deletedIds = {};
+
+  Future<void> _delete(String id) async {
+    setState(() => _deletedIds.add(id));
+    try {
+      await ref.read(analysisRepositoryProvider).delete(id);
+      ref.invalidate(analysisHistoryProvider);
+    } catch (_) {
+      // 실패 시 복원
+      setState(() => _deletedIds.remove(id));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final history = ref.watch(analysisHistoryProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('분석')),
       body: history.when(
-        data: (items) {
+        data: (allItems) {
+          final items =
+              allItems.where((e) => !_deletedIds.contains(e.id)).toList();
+
           if (items.isEmpty) {
             return Center(
               child: Column(
@@ -37,6 +59,7 @@ class AnalysisTabPage extends ConsumerWidget {
               ),
             );
           }
+
           return ListView.builder(
             padding: const EdgeInsets.only(top: 8, bottom: 80),
             itemCount: items.length,
@@ -68,7 +91,8 @@ class AnalysisTabPage extends ConsumerWidget {
                         onPressed: () =>
                             Navigator.of(dialogContext).pop(false),
                         child: Text('취소',
-                            style: TextStyle(color: AppColors.textSecondary)),
+                            style:
+                                TextStyle(color: AppColors.textSecondary)),
                       ),
                       TextButton(
                         onPressed: () =>
@@ -79,10 +103,7 @@ class AnalysisTabPage extends ConsumerWidget {
                     ],
                   ),
                 ),
-                onDismissed: (_) async {
-                  await ref.read(analysisRepositoryProvider).delete(item.id);
-                  ref.invalidate(analysisHistoryProvider);
-                },
+                onDismissed: (_) => _delete(item.id),
                 child: AnalysisHistoryCard(
                   result: item,
                   onTap: () =>

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -59,18 +59,20 @@ class AnalysisTabPage extends ConsumerWidget {
                 ),
                 confirmDismiss: (_) => showDialog<bool>(
                   context: context,
-                  builder: (_) => AlertDialog(
+                  builder: (dialogContext) => AlertDialog(
                     backgroundColor: AppColors.darkCard,
                     title: const Text('기록 삭제'),
                     content: const Text('이 분석 기록을 삭제할까요?'),
                     actions: [
                       TextButton(
-                        onPressed: () => Navigator.pop(context, false),
+                        onPressed: () =>
+                            Navigator.of(dialogContext).pop(false),
                         child: Text('취소',
                             style: TextStyle(color: AppColors.textSecondary)),
                       ),
                       TextButton(
-                        onPressed: () => Navigator.pop(context, true),
+                        onPressed: () =>
+                            Navigator.of(dialogContext).pop(true),
                         child: Text('삭제',
                             style: TextStyle(color: AppColors.error)),
                       ),

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/providers/analysis_provider.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_history_card.dart';
 import 'package:bowling_diary/shared/widgets/loading_widget.dart';
@@ -47,9 +47,7 @@ class AnalysisTabPage extends ConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton(
         backgroundColor: AppColors.neonOrange,
-        onPressed: () => Navigator.of(context, rootNavigator: true).push(
-          MaterialPageRoute(builder: (_) => const AnalysisGuidePage()),
-        ).then((_) => ref.invalidate(analysisHistoryProvider)),
+        onPressed: () => context.push('/analysis/guide'),
         child: const Icon(Icons.videocam, color: Colors.black),
       ),
     );

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -40,14 +40,58 @@ class AnalysisTabPage extends ConsumerWidget {
           return ListView.builder(
             padding: const EdgeInsets.only(top: 8, bottom: 80),
             itemCount: items.length,
-            itemBuilder: (_, i) => AnalysisHistoryCard(
-              result: items[i],
-              onTap: () => Navigator.of(context, rootNavigator: true).push(
-                MaterialPageRoute(
-                  builder: (_) => AnalysisDetailPage(result: items[i]),
+            itemBuilder: (_, i) {
+              final item = items[i];
+              return Dismissible(
+                key: ValueKey(item.id),
+                direction: DismissDirection.endToStart,
+                background: Container(
+                  margin: const EdgeInsets.symmetric(
+                      horizontal: 16, vertical: 5),
+                  decoration: BoxDecoration(
+                    color: AppColors.error,
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  alignment: Alignment.centerRight,
+                  padding: const EdgeInsets.only(right: 24),
+                  child: const Icon(Icons.delete_outline_rounded,
+                      color: Colors.white, size: 24),
                 ),
-              ),
-            ),
+                confirmDismiss: (_) => showDialog<bool>(
+                  context: context,
+                  builder: (_) => AlertDialog(
+                    backgroundColor: AppColors.darkCard,
+                    title: const Text('기록 삭제'),
+                    content: const Text('이 분석 기록을 삭제할까요?'),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context, false),
+                        child: Text('취소',
+                            style: TextStyle(color: AppColors.textSecondary)),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(context, true),
+                        child: Text('삭제',
+                            style: TextStyle(color: AppColors.error)),
+                      ),
+                    ],
+                  ),
+                ),
+                onDismissed: (_) async {
+                  await ref.read(analysisRepositoryProvider).delete(item.id);
+                  ref.invalidate(analysisHistoryProvider);
+                },
+                child: AnalysisHistoryCard(
+                  result: item,
+                  onTap: () =>
+                      Navigator.of(context, rootNavigator: true).push(
+                    MaterialPageRoute(
+                      builder: (_) => AnalysisDetailPage(result: item),
+                    ),
+                  ),
+                ),
+              );
+            },
           );
         },
         loading: () => const LoadingWidget(),

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_detail_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_selection_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/providers/analysis_provider.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_history_card.dart';
@@ -15,7 +16,7 @@ class AnalysisTabPage extends ConsumerWidget {
     final history = ref.watch(analysisHistoryProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('볼 분석')),
+      appBar: AppBar(title: const Text('분석')),
       body: history.when(
         data: (items) {
           if (items.isEmpty) {
@@ -23,7 +24,8 @@ class AnalysisTabPage extends ConsumerWidget {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.videocam_outlined, size: 72, color: AppColors.textHint),
+                  Icon(Icons.videocam_outlined,
+                      size: 72, color: AppColors.textHint),
                   const SizedBox(height: 16),
                   Text('아직 측정 기록이 없어요',
                       style: AppTextStyles.headingSmall
@@ -38,7 +40,14 @@ class AnalysisTabPage extends ConsumerWidget {
           return ListView.builder(
             padding: const EdgeInsets.only(top: 8, bottom: 80),
             itemCount: items.length,
-            itemBuilder: (_, i) => AnalysisHistoryCard(result: items[i]),
+            itemBuilder: (_, i) => AnalysisHistoryCard(
+              result: items[i],
+              onTap: () => Navigator.of(context, rootNavigator: true).push(
+                MaterialPageRoute(
+                  builder: (_) => AnalysisDetailPage(result: items[i]),
+                ),
+              ),
+            ),
           );
         },
         loading: () => const LoadingWidget(),
@@ -47,7 +56,8 @@ class AnalysisTabPage extends ConsumerWidget {
       floatingActionButton: FloatingActionButton(
         backgroundColor: AppColors.neonOrange,
         onPressed: () => Navigator.of(context, rootNavigator: true)
-            .push(MaterialPageRoute(builder: (_) => const AnalysisSelectionPage()))
+            .push(MaterialPageRoute(
+                builder: (_) => const AnalysisSelectionPage()))
             .then((_) => ref.invalidate(analysisHistoryProvider)),
         child: const Icon(Icons.add, color: Colors.black),
       ),

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -1,18 +1,153 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/providers/analysis_provider.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_history_card.dart';
 import 'package:bowling_diary/shared/widgets/loading_widget.dart';
 
-class AnalysisTabPage extends ConsumerWidget {
+class AnalysisTabPage extends ConsumerStatefulWidget {
   const AnalysisTabPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<AnalysisTabPage> createState() => _AnalysisTabPageState();
+}
+
+class _AnalysisTabPageState extends ConsumerState<AnalysisTabPage> {
+  final _frameExtractor = VideoFrameExtractorService();
+  final _analysisService = VideoAnalysisService();
+  bool _isAnalyzing = false;
+
+  void _onFabTapped() {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: AppColors.darkCard,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 40,
+                height: 4,
+                margin: const EdgeInsets.only(bottom: 20),
+                decoration: BoxDecoration(
+                  color: AppColors.textHint,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              ListTile(
+                leading: Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    color: AppColors.neonOrange.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Icon(Icons.videocam, color: AppColors.neonOrange),
+                ),
+                title: Text('즉시 촬영하기', style: AppTextStyles.bodyLarge),
+                subtitle: Text('카메라로 투구 영상을 녹화합니다',
+                    style: AppTextStyles.bodySmall.copyWith(color: AppColors.textSecondary)),
+                onTap: () {
+                  Navigator.pop(context);
+                  _goToRecord();
+                },
+              ),
+              ListTile(
+                leading: Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    color: AppColors.neonOrange.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Icon(Icons.photo_library_outlined, color: AppColors.neonOrange),
+                ),
+                title: Text('갤러리에서 가져오기', style: AppTextStyles.bodyLarge),
+                subtitle: Text('저장된 영상으로 분석합니다',
+                    style: AppTextStyles.bodySmall.copyWith(color: AppColors.textSecondary)),
+                onTap: () {
+                  Navigator.pop(context);
+                  _pickFromGallery();
+                },
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _goToRecord() {
+    Navigator.of(context, rootNavigator: true)
+        .push(MaterialPageRoute(builder: (_) => const AnalysisGuidePage()))
+        .then((_) => ref.invalidate(analysisHistoryProvider));
+  }
+
+  Future<void> _pickFromGallery() async {
+    final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
+    if (video == null || !mounted) return;
+
+    setState(() => _isAnalyzing = true);
+    try {
+      final result = await _frameExtractor.extract(video.path);
+      final analysisData = _analysisService.analyzeImages(
+        result.frames,
+        result.originalFps,
+      );
+
+      if (!mounted) return;
+      setState(() => _isAnalyzing = false);
+
+      await Navigator.of(context, rootNavigator: true).push(
+        MaterialPageRoute(
+          builder: (_) => AnalysisResultPage(
+            analysisData: analysisData,
+            videoPath: video.path,
+            recordedAt: DateTime.now(),
+          ),
+        ),
+      );
+      ref.invalidate(analysisHistoryProvider);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isAnalyzing = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('영상 분석 실패: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final history = ref.watch(analysisHistoryProvider);
+
+    if (_isAnalyzing) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('볼 분석')),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(color: AppColors.neonOrange),
+              const SizedBox(height: 24),
+              Text('영상 분석 중...', style: AppTextStyles.bodyLarge),
+            ],
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(title: const Text('볼 분석')),
@@ -23,8 +158,7 @@ class AnalysisTabPage extends ConsumerWidget {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.videocam_outlined,
-                      size: 72, color: AppColors.textHint),
+                  Icon(Icons.videocam_outlined, size: 72, color: AppColors.textHint),
                   const SizedBox(height: 16),
                   Text('아직 측정 기록이 없어요',
                       style: AppTextStyles.headingSmall
@@ -47,10 +181,8 @@ class AnalysisTabPage extends ConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton(
         backgroundColor: AppColors.neonOrange,
-        onPressed: () => Navigator.of(context, rootNavigator: true).push(
-          MaterialPageRoute(builder: (_) => const AnalysisGuidePage()),
-        ).then((_) => ref.invalidate(analysisHistoryProvider)),
-        child: const Icon(Icons.videocam, color: Colors.black),
+        onPressed: _onFabTapped,
+        child: const Icon(Icons.add, color: Colors.black),
       ),
     );
   }

--- a/lib/features/analysis/presentation/pages/analysis_trim_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_trim_page.dart
@@ -177,31 +177,36 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
       appBar: AppBar(title: const Text('구간 선택')),
       body: Column(
         children: [
-          // 영상 미리보기
-          GestureDetector(
-            onTap: _togglePlay,
-            child: AspectRatio(
-              aspectRatio: _controller!.value.aspectRatio,
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  VideoPlayer(_controller!),
-                  if (!_controller!.value.isPlaying)
-                    Container(
-                      color: Colors.black38,
-                      child: const Icon(
-                        Icons.play_arrow,
-                        color: Colors.white,
-                        size: 64,
+          // 영상 미리보기 (최대 화면 45%)
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxHeight: MediaQuery.of(context).size.height * 0.45,
+            ),
+            child: GestureDetector(
+              onTap: _togglePlay,
+              child: AspectRatio(
+                aspectRatio: _controller!.value.aspectRatio,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    VideoPlayer(_controller!),
+                    if (!_controller!.value.isPlaying)
+                      Container(
+                        color: Colors.black38,
+                        child: const Icon(
+                          Icons.play_arrow,
+                          color: Colors.white,
+                          size: 64,
+                        ),
                       ),
-                    ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
 
           Expanded(
-            child: Padding(
+            child: SingleChildScrollView(
               padding: const EdgeInsets.fromLTRB(24, 20, 24, 0),
               child: Column(
                 children: [
@@ -250,7 +255,7 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
                     textAlign: TextAlign.center,
                   ),
 
-                  const Spacer(),
+                  const SizedBox(height: 24),
 
                   SizedBox(
                     width: double.infinity,

--- a/lib/features/analysis/presentation/pages/analysis_trim_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_trim_page.dart
@@ -1,0 +1,283 @@
+import 'dart:io';
+import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:video_player/video_player.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/features/analysis/data/services/gemini_analysis_service.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_loading_widget.dart';
+
+class AnalysisTrimPage extends StatefulWidget {
+  final String videoPath;
+  final int fps;
+
+  const AnalysisTrimPage({
+    super.key,
+    required this.videoPath,
+    required this.fps,
+  });
+
+  @override
+  State<AnalysisTrimPage> createState() => _AnalysisTrimPageState();
+}
+
+class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
+  final _geminiService = GeminiAnalysisService();
+  final _fallbackService = VideoAnalysisService();
+  final _frameExtractor = VideoFrameExtractorService();
+
+  VideoPlayerController? _controller;
+  double _startSec = 0;
+  double _endSec = 0;
+  double _totalSec = 0;
+  bool _isAnalyzing = false;
+  String? _trimmedPath;
+
+  @override
+  void initState() {
+    super.initState();
+    _initVideo();
+  }
+
+  Future<void> _initVideo() async {
+    final ctrl = VideoPlayerController.file(File(widget.videoPath));
+    await ctrl.initialize();
+    await ctrl.setLooping(false);
+    ctrl.addListener(_onPositionChanged);
+
+    final total = ctrl.value.duration.inMilliseconds / 1000.0;
+    if (!mounted) return;
+    setState(() {
+      _controller = ctrl;
+      _totalSec = total;
+      _startSec = 0;
+      _endSec = total;
+    });
+  }
+
+  void _onPositionChanged() {
+    if (_controller == null || !mounted) return;
+    final pos = _controller!.value.position.inMilliseconds / 1000.0;
+    if (_controller!.value.isPlaying && pos >= _endSec) {
+      _controller!.seekTo(Duration(milliseconds: (_startSec * 1000).round()));
+      _controller!.pause();
+    }
+    setState(() {});
+  }
+
+  void _onRangeChanged(RangeValues values) {
+    if (values.end - values.start < 0.5) return;
+    setState(() {
+      _startSec = values.start;
+      _endSec = values.end;
+    });
+    _controller?.seekTo(Duration(milliseconds: (_startSec * 1000).round()));
+    _controller?.pause();
+  }
+
+  void _togglePlay() {
+    if (_controller == null) return;
+    if (_controller!.value.isPlaying) {
+      _controller!.pause();
+    } else {
+      _controller!.seekTo(Duration(milliseconds: (_startSec * 1000).round()));
+      _controller!.play();
+    }
+  }
+
+  Future<void> _startAnalysis() async {
+    setState(() => _isAnalyzing = true);
+
+    try {
+      // 1. ffmpeg로 선택 구간 자르기
+      final tempDir = await getTemporaryDirectory();
+      final trimmedPath =
+          '${tempDir.path}/trimmed_${DateTime.now().millisecondsSinceEpoch}.mp4';
+
+      final session = await FFmpegKit.execute(
+        '-i "${widget.videoPath}" -ss $_startSec -to $_endSec -c copy "$trimmedPath"',
+      );
+      final rc = await session.getReturnCode();
+      if (rc == null || !rc.isValueSuccess()) throw Exception('영상 자르기 실패');
+
+      if (mounted) setState(() => _trimmedPath = trimmedPath);
+
+      // 2. Gemini 분석 (실패 시 로컬 fallback)
+      AnalysisData analysisData;
+      try {
+        analysisData = await _geminiService.analyzeVideo(trimmedPath, widget.fps);
+      } on GeminiQuotaExceededException {
+        debugPrint('[Trim] Gemini 할당량 초과 → 로컬 fallback');
+        final extracted = await _frameExtractor.extract(trimmedPath);
+        analysisData = _fallbackService.analyzeImages(
+            extracted.frames, extracted.originalFps);
+      } on GeminiApiException catch (e) {
+        debugPrint('[Trim] Gemini 오류 → fallback: $e');
+        final extracted = await _frameExtractor.extract(trimmedPath);
+        analysisData = _fallbackService.analyzeImages(
+            extracted.frames, extracted.originalFps);
+      }
+
+      if (!mounted) return;
+      await Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => AnalysisResultPage(
+            analysisData: analysisData,
+            videoPath: trimmedPath,
+            recordedAt: DateTime.now(),
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isAnalyzing = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('분석 실패: $e')),
+      );
+    }
+  }
+
+  String _fmt(double seconds) {
+    final m = (seconds ~/ 60).toString().padLeft(2, '0');
+    final s = (seconds % 60).toStringAsFixed(1).padLeft(4, '0');
+    return '$m:$s';
+  }
+
+  @override
+  void dispose() {
+    _controller?.removeListener(_onPositionChanged);
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isAnalyzing) {
+      return Scaffold(
+        body: AnalysisLoadingWidget(
+          videoPath: _trimmedPath ?? widget.videoPath,
+        ),
+      );
+    }
+
+    if (_controller == null || !_controller!.value.isInitialized) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final selectedDuration = _endSec - _startSec;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('구간 선택')),
+      body: Column(
+        children: [
+          // 영상 미리보기
+          GestureDetector(
+            onTap: _togglePlay,
+            child: AspectRatio(
+              aspectRatio: _controller!.value.aspectRatio,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  VideoPlayer(_controller!),
+                  if (!_controller!.value.isPlaying)
+                    Container(
+                      color: Colors.black38,
+                      child: const Icon(
+                        Icons.play_arrow,
+                        color: Colors.white,
+                        size: 64,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(24, 20, 24, 0),
+              child: Column(
+                children: [
+                  // 구간 정보
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(_fmt(_startSec),
+                          style: AppTextStyles.bodySmall
+                              .copyWith(color: AppColors.textSecondary)),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 6),
+                        decoration: BoxDecoration(
+                          color: AppColors.neonOrange.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Text(
+                          '${selectedDuration.toStringAsFixed(1)}초 선택됨',
+                          style: AppTextStyles.bodySmall
+                              .copyWith(color: AppColors.neonOrange),
+                        ),
+                      ),
+                      Text(_fmt(_endSec),
+                          style: AppTextStyles.bodySmall
+                              .copyWith(color: AppColors.textSecondary)),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+
+                  // 구간 슬라이더
+                  RangeSlider(
+                    values: RangeValues(_startSec, _endSec),
+                    min: 0,
+                    max: _totalSec,
+                    divisions: (_totalSec * 10).round().clamp(1, 1000),
+                    activeColor: AppColors.neonOrange,
+                    inactiveColor: AppColors.textHint,
+                    onChanged: _onRangeChanged,
+                  ),
+
+                  Text(
+                    '투구 시작(릴리즈)부터 핀 충돌까지 구간을 선택하세요\n짧을수록 분석이 정확합니다',
+                    style: AppTextStyles.bodySmall
+                        .copyWith(color: AppColors.textSecondary),
+                    textAlign: TextAlign.center,
+                  ),
+
+                  const Spacer(),
+
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.neonOrange,
+                        foregroundColor: Colors.black,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      onPressed: _startAnalysis,
+                      child: Text(
+                        '분석 시작',
+                        style: AppTextStyles.bodyLarge
+                            .copyWith(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/analysis/presentation/widgets/analysis_history_card.dart
+++ b/lib/features/analysis/presentation/widgets/analysis_history_card.dart
@@ -6,46 +6,114 @@ import 'package:bowling_diary/features/analysis/domain/entities/analysis_result_
 
 class AnalysisHistoryCard extends StatelessWidget {
   final AnalysisResultEntity result;
+  final VoidCallback? onTap;
 
-  const AnalysisHistoryCard({super.key, required this.result});
+  const AnalysisHistoryCard({super.key, required this.result, this.onTap});
 
   @override
   Widget build(BuildContext context) {
-    final dateStr = DateFormat('MM.dd HH:mm').format(result.recordedAt);
-    final rpmText = result.rpmEstimated != null
-        ? '${result.rpmEstimated} RPM (추정)'
-        : 'RPM 측정 불가';
+    final date = DateFormat('MM.dd').format(result.recordedAt);
+    final time = DateFormat('HH:mm').format(result.recordedAt);
+    final hasSpeed = result.speedKmh > 0;
+    final hasRpm = result.rpmEstimated != null;
 
-    return Card(
-      color: AppColors.darkCard,
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        decoration: BoxDecoration(
+          color: AppColors.darkCard,
+          borderRadius: BorderRadius.circular(16),
+        ),
         child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            Icon(Icons.sports_baseball, color: AppColors.neonOrange, size: 32),
-            const SizedBox(width: 16),
+            // 날짜
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  date,
+                  style: AppTextStyles.bodySmall.copyWith(
+                    color: AppColors.textSecondary,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 13,
+                  ),
+                ),
+                Text(
+                  time,
+                  style: AppTextStyles.bodySmall.copyWith(
+                    color: AppColors.textHint,
+                    fontSize: 11,
+                  ),
+                ),
+              ],
+            ),
+            Container(
+              width: 1,
+              height: 40,
+              margin: const EdgeInsets.symmetric(horizontal: 16),
+              color: AppColors.darkDivider,
+            ),
+            // 구속
             Expanded(
+              flex: 5,
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(dateStr,
-                      style: AppTextStyles.bodySmall
-                          .copyWith(color: AppColors.textSecondary)),
-                  const SizedBox(height: 4),
-                  Text(
-                    '${result.speedKmh.toStringAsFixed(1)} km/h',
-                    style: AppTextStyles.headingSmall
-                        .copyWith(color: AppColors.textPrimary),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        hasSpeed
+                            ? result.speedKmh.toStringAsFixed(1)
+                            : '—',
+                        style: TextStyle(
+                          fontSize: 26,
+                          fontWeight: FontWeight.w800,
+                          color: hasSpeed
+                              ? AppColors.neonOrange
+                              : AppColors.textHint,
+                          height: 1.0,
+                          letterSpacing: -0.5,
+                        ),
+                      ),
+                      if (hasSpeed)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 3, left: 3),
+                          child: Text(
+                            'km/h',
+                            style: AppTextStyles.bodySmall.copyWith(
+                              color: AppColors.neonOrange.withValues(alpha: 0.7),
+                              fontSize: 11,
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
-                  Text(rpmText,
-                      style: AppTextStyles.bodySmall
-                          .copyWith(color: AppColors.textSecondary)),
+                  const SizedBox(height: 2),
+                  Text(
+                    hasRpm ? '${result.rpmEstimated} RPM' : 'RPM 미측정',
+                    style: AppTextStyles.bodySmall.copyWith(
+                      color: AppColors.textSecondary,
+                      fontSize: 12,
+                    ),
+                  ),
                 ],
               ),
             ),
-            if (result.linkedSessionId != null)
-              Icon(Icons.link, color: AppColors.neonOrange, size: 18),
+            // 우측 아이콘
+            Column(
+              children: [
+                if (result.linkedSessionId != null)
+                  Icon(Icons.link_rounded,
+                      color: AppColors.textHint, size: 16),
+                const SizedBox(height: 4),
+                Icon(Icons.chevron_right_rounded,
+                    color: AppColors.textHint, size: 18),
+              ],
+            ),
           ],
         ),
       ),

--- a/lib/features/analysis/presentation/widgets/analysis_loading_widget.dart
+++ b/lib/features/analysis/presentation/widgets/analysis_loading_widget.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+
+class AnalysisLoadingWidget extends StatefulWidget {
+  final String? videoPath;
+
+  const AnalysisLoadingWidget({super.key, this.videoPath});
+
+  @override
+  State<AnalysisLoadingWidget> createState() => _AnalysisLoadingWidgetState();
+}
+
+class _AnalysisLoadingWidgetState extends State<AnalysisLoadingWidget> {
+  VideoPlayerController? _controller;
+  bool _videoReady = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.videoPath != null) _initVideo(widget.videoPath!);
+  }
+
+  Future<void> _initVideo(String path) async {
+    try {
+      final ctrl = VideoPlayerController.file(File(path));
+      await ctrl.initialize();
+      await ctrl.setLooping(true);
+      await ctrl.setVolume(0);
+      await ctrl.play();
+      if (!mounted) return;
+      setState(() {
+        _controller = ctrl;
+        _videoReady = true;
+      });
+    } catch (_) {
+      // 영상 로드 실패 시 스피너로 fallback
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        if (_videoReady && _controller != null)
+          FittedBox(
+            fit: BoxFit.cover,
+            child: SizedBox(
+              width: _controller!.value.size.width,
+              height: _controller!.value.size.height,
+              child: VideoPlayer(_controller!),
+            ),
+          ),
+        Container(
+          color: Colors.black.withValues(alpha: _videoReady ? 0.5 : 1.0),
+        ),
+        Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(
+                color: AppColors.neonOrange,
+                strokeWidth: 3,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                '영상 분석 중...',
+                style: AppTextStyles.bodyLarge.copyWith(color: Colors.white),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '볼 궤적을 추적하고 있어요',
+                style: AppTextStyles.bodySmall.copyWith(color: Colors.white70),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -66,9 +66,11 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   Future<void> _init() async {
+    if (!mounted) return;
     state = AuthStateLoading();
     final session = _supabase.auth.currentSession;
     if (session == null) {
+      if (!mounted) return;
       state = AuthStateUnauthenticated();
       return;
     }
@@ -83,6 +85,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
           .eq('id', userId)
           .maybeSingle();
 
+      if (!mounted) return;
       if (data == null) {
         state = AuthStateNeedsProfile(userId);
       } else {
@@ -94,6 +97,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
         }
       }
     } catch (e) {
+      if (!mounted) return;
       state = AuthStateNeedsProfile(userId);
     }
   }
@@ -271,9 +275,11 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   void _handleAuthStateChange(AuthChangeEvent event, Session? session) {
+    if (!mounted) return;
     if (event == AuthChangeEvent.signedIn && session != null) {
       _loadUserProfile(session.user.id);
     } else if (event == AuthChangeEvent.signedOut) {
+      if (!mounted) return;
       state = AuthStateUnauthenticated();
     }
   }

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -37,9 +37,7 @@ class AuthStateError extends AuthState {
 
 final authNotifierProvider =
     StateNotifierProvider<AuthNotifier, AuthState>((ref) {
-  final notifier = AuthNotifier();
-  ref.onDispose(() => notifier.dispose());
-  return notifier;
+  return AuthNotifier();
 });
 
 final currentUserProvider = Provider<UserEntity?>((ref) {

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -13,7 +13,6 @@ class SettingsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.watch(colorThemeProvider);
     final user = ref.watch(currentUserProvider);
     final isAdmin = user?.isAdmin ?? false;
 

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/shared/providers/theme_provider.dart';
 import 'package:bowling_diary/features/auth/presentation/providers/auth_provider.dart';
 import 'package:bowling_diary/features/settings/presentation/pages/theme_selection_page.dart';
 
@@ -12,6 +13,7 @@ class SettingsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(colorThemeProvider);
     final user = ref.watch(currentUserProvider);
     final isAdmin = user?.isAdmin ?? false;
 

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -245,7 +245,7 @@ class _ColorThemeSelector extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: AppColorTheme.values.map((theme) {
-          final palette = ColorThemes.fromTheme(theme);
+          final palette = ColorThemes.previewLight(theme);
           final isSelected = theme == currentTheme;
           return GestureDetector(
             onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
@@ -296,14 +296,12 @@ class _ColorThemeSelector extends StatelessWidget {
 
   String _themeName(AppColorTheme theme) {
     switch (theme) {
-      case AppColorTheme.dark:
-        return '다크';
+      case AppColorTheme.blue:
+        return '블루';
       case AppColorTheme.cream:
         return '크림';
       case AppColorTheme.lavender:
         return '라벤더';
-      case AppColorTheme.tossBlue:
-        return '블루';
     }
   }
 }

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -4,9 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
-import 'package:bowling_diary/app/theme/color_themes.dart';
 import 'package:bowling_diary/features/auth/presentation/providers/auth_provider.dart';
-import 'package:bowling_diary/shared/providers/theme_provider.dart';
+import 'package:bowling_diary/features/settings/presentation/pages/theme_selection_page.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -17,132 +16,100 @@ class SettingsPage extends ConsumerWidget {
     final isAdmin = user?.isAdmin ?? false;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('설정')),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          // 프로필 카드
-          Container(
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              color: AppColors.darkCard,
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: AppColors.darkDivider),
-            ),
-            child: Row(
-              children: [
-                CircleAvatar(
-                  radius: 28,
-                  backgroundColor: AppColors.neonOrange.withValues(alpha: 0.15),
-                  child: Text(
-                    (user?.nickname ?? '?')[0].toUpperCase(),
-                    style: TextStyle(color: AppColors.neonOrange, fontSize: 22, fontWeight: FontWeight.w800),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(user?.nickname ?? '닉네임 없음', style: AppTextStyles.labelLarge),
-                      const SizedBox(height: 4),
-                      Row(
-                        children: [
-                          if (user?.bowlingStyle != null && user!.bowlingStyle!.isNotEmpty)
-                            Text(user.bowlingStyle!, style: AppTextStyles.bodySmall),
-                          if (isAdmin) ...[
-                            const SizedBox(width: 8),
-                            Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                              decoration: BoxDecoration(
-                                color: AppColors.neonOrange.withValues(alpha: 0.15),
-                                borderRadius: BorderRadius.circular(4),
-                              ),
-                              child: Text('관리자', style: TextStyle(color: AppColors.neonOrange, fontSize: 10, fontWeight: FontWeight.w700)),
-                            ),
-                          ],
-                        ],
+      backgroundColor: AppColors.darkBg,
+      body: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(child: _ProfileHeader(user: user, isAdmin: isAdmin)),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 28, 20, 0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 관리자
+                  if (isAdmin) ...[
+                    _SectionLabel('관리자'),
+                    const SizedBox(height: 8),
+                    _MenuItem(
+                      icon: Icons.sports_baseball_outlined,
+                      label: '카탈로그 관리',
+                      onTap: () => context.push('/admin/catalog'),
+                      accent: true,
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+
+                  // 내 정보
+                  _SectionLabel('내 정보'),
+                  const SizedBox(height: 8),
+                  _MenuGroup(items: [
+                    _MenuItem(
+                      icon: Icons.sports_baseball_outlined,
+                      label: '내 볼',
+                      onTap: () => context.push('/balls'),
+                    ),
+                    _MenuItem(
+                      icon: Icons.edit_outlined,
+                      label: '프로필 수정',
+                      onTap: () => context.push('/profile-setup'),
+                      isLast: true,
+                    ),
+                  ]),
+                  const SizedBox(height: 24),
+
+                  // 앱 설정
+                  _SectionLabel('앱 설정'),
+                  const SizedBox(height: 8),
+                  _MenuGroup(items: [
+                    _MenuItem(
+                      icon: Icons.palette_outlined,
+                      label: '테마',
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => const ThemeSelectionPage()),
                       ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 24),
+                      isLast: true,
+                    ),
+                  ]),
+                  const SizedBox(height: 24),
 
-          // 관리자 섹션
-          if (isAdmin) ...[
-            Text('관리자', style: AppTextStyles.labelSmall.copyWith(color: AppColors.neonOrange)),
-            const SizedBox(height: 8),
-            _SettingsTile(
-              icon: Icons.sports_baseball,
-              title: '카탈로그 관리',
-              subtitle: '볼링볼 카탈로그 추가/수정/삭제',
-              onTap: () => context.push('/admin/catalog'),
-            ),
-            const SizedBox(height: 24),
-          ],
+                  // 계정
+                  _SectionLabel('계정'),
+                  const SizedBox(height: 8),
+                  _MenuGroup(items: [
+                    _MenuItem(
+                      icon: Icons.logout_rounded,
+                      label: '로그아웃',
+                      onTap: () =>
+                          ref.read(authNotifierProvider.notifier).signOut(),
+                    ),
+                    _MenuItem(
+                      icon: Icons.delete_outline_rounded,
+                      label: '회원 탈퇴',
+                      onTap: () => _confirmDeleteAccount(context, ref),
+                      destructive: true,
+                      isLast: true,
+                    ),
+                  ]),
+                  const SizedBox(height: 40),
 
-          // 테마 섹션
-          Text('테마', style: AppTextStyles.labelSmall),
-          const SizedBox(height: 8),
-          _ColorThemeSelector(ref: ref),
-          const SizedBox(height: 24),
-
-          // 일반 섹션
-          Text('일반', style: AppTextStyles.labelSmall),
-          const SizedBox(height: 8),
-          _SettingsTile(
-            icon: Icons.person_outline,
-            title: '프로필 수정',
-            subtitle: '닉네임, 투구 스타일 변경',
-            onTap: () => context.push('/profile-setup'),
-          ),
-          const SizedBox(height: 32),
-
-          // 계정 섹션
-          Text('계정', style: AppTextStyles.labelSmall),
-          const SizedBox(height: 8),
-          SizedBox(
-            width: double.infinity,
-            height: 48,
-            child: OutlinedButton(
-              onPressed: () => ref.read(authNotifierProvider.notifier).signOut(),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: AppColors.textSecondary,
-                side: BorderSide(color: AppColors.darkDivider),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  Center(child: _AppVersionInfo()),
+                  const SizedBox(height: 32),
+                ],
               ),
-              child: const Text('로그아웃'),
             ),
           ),
-          const SizedBox(height: 12),
-          SizedBox(
-            width: double.infinity,
-            height: 48,
-            child: OutlinedButton(
-              onPressed: () => _confirmDeleteAccount(context, ref),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: AppColors.error,
-                side: BorderSide(color: AppColors.error),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-              ),
-              child: const Text('회원 탈퇴'),
-            ),
-          ),
-          const SizedBox(height: 32),
-          _AppVersionInfo(),
-          const SizedBox(height: 24),
         ],
       ),
     );
   }
 
   Future<void> _confirmDeleteAccount(BuildContext context, WidgetRef ref) async {
-    final firstConfirm = await showDialog<bool>(
+    final first = await showDialog<bool>(
       context: context,
       builder: (c) => AlertDialog(
+        backgroundColor: AppColors.darkCard,
         title: const Text('회원 탈퇴'),
         content: const Text('정말 탈퇴하시겠습니까?\n모든 기록과 데이터가 삭제되며 복구할 수 없습니다.'),
         actions: [
@@ -154,157 +121,221 @@ class SettingsPage extends ConsumerWidget {
         ],
       ),
     );
-    if (firstConfirm != true || !context.mounted) return;
+    if (first != true || !context.mounted) return;
 
-    final secondConfirm = await showDialog<bool>(
+    final second = await showDialog<bool>(
       context: context,
       builder: (c) => AlertDialog(
+        backgroundColor: AppColors.darkCard,
         title: const Text('마지막 확인'),
         content: const Text('삭제된 데이터는 절대 복구할 수 없습니다.\n정말로 진행하시겠습니까?'),
         actions: [
           TextButton(onPressed: () => Navigator.pop(c, false), child: const Text('취소')),
           TextButton(
             onPressed: () => Navigator.pop(c, true),
-            child: Text('삭제 및 탈퇴', style: TextStyle(color: AppColors.error, fontWeight: FontWeight.w700)),
+            child: Text('삭제 및 탈퇴',
+                style: TextStyle(color: AppColors.error, fontWeight: FontWeight.w700)),
           ),
         ],
       ),
     );
-    if (secondConfirm != true || !context.mounted) return;
+    if (second != true || !context.mounted) return;
 
     try {
       await ref.read(authNotifierProvider.notifier).deleteAccount();
-    } catch (e) {
-      debugPrint('회원 탈퇴 에러: $e');
+    } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('탈퇴 처리 중 오류가 발생했습니다'), backgroundColor: AppColors.error, behavior: SnackBarBehavior.floating),
-        );
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: const Text('탈퇴 처리 중 오류가 발생했습니다'),
+          backgroundColor: AppColors.error,
+          behavior: SnackBarBehavior.floating,
+        ));
       }
     }
   }
 }
 
-class _SettingsTile extends StatelessWidget {
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final VoidCallback onTap;
+// ─── 프로필 헤더 ─────────────────────────────────────────────────────────────
 
-  const _SettingsTile({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-    required this.onTap,
-  });
+class _ProfileHeader extends StatelessWidget {
+  final dynamic user;
+  final bool isAdmin;
+
+  const _ProfileHeader({required this.user, required this.isAdmin});
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.only(bottom: 8),
+      width: double.infinity,
       decoration: BoxDecoration(
-        color: AppColors.darkCard,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: AppColors.darkDivider),
-      ),
-      child: ListTile(
-        leading: Container(
-          width: 40,
-          height: 40,
-          decoration: BoxDecoration(
-            color: AppColors.darkDivider,
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: Icon(icon, color: AppColors.textSecondary, size: 20),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppColors.neonOrange.withValues(alpha: 0.2),
+            AppColors.darkBg,
+          ],
         ),
-        title: Text(title, style: TextStyle(color: AppColors.textPrimary, fontWeight: FontWeight.w600, fontSize: 14)),
-        subtitle: Text(subtitle, style: AppTextStyles.labelSmall),
-        trailing: Icon(Icons.chevron_right, color: AppColors.textHint, size: 20),
-        onTap: onTap,
+      ),
+      child: SafeArea(
+        bottom: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 28, 24, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '마이페이지',
+                style: TextStyle(
+                  color: AppColors.textHint,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 1.5,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                user?.nickname ?? '닉네임 없음',
+                style: TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 28,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: -0.5,
+                ),
+              ),
+              if (user?.bowlingStyle != null &&
+                  (user!.bowlingStyle as String).isNotEmpty) ...[
+                const SizedBox(height: 4),
+                Text(
+                  user!.bowlingStyle as String,
+                  style: AppTextStyles.bodyMedium
+                      .copyWith(color: AppColors.textSecondary),
+                ),
+              ],
+              if (isAdmin) ...[
+                const SizedBox(height: 8),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: AppColors.neonOrange.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(5),
+                  ),
+                  child: Text(
+                    'ADMIN',
+                    style: TextStyle(
+                      color: AppColors.neonOrange,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 1.2,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
       ),
     );
   }
 }
 
-class _ColorThemeSelector extends StatelessWidget {
-  final WidgetRef ref;
+// ─── 공통 위젯 ────────────────────────────────────────────────────────────────
 
-  const _ColorThemeSelector({required this.ref});
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
 
   @override
   Widget build(BuildContext context) {
-    final currentTheme = ref.watch(colorThemeProvider);
-
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppColors.darkCard,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: AppColors.darkDivider),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: AppColorTheme.values.map((theme) {
-          final palette = ColorThemes.fromTheme(theme);
-          final isSelected = theme == currentTheme;
-          return GestureDetector(
-            onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
-            child: Column(
-              children: [
-                AnimatedContainer(
-                  duration: const Duration(milliseconds: 200),
-                  width: 48,
-                  height: 48,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    border: Border.all(
-                      color: isSelected ? palette.primary : Colors.transparent,
-                      width: 2.5,
-                    ),
-                  ),
-                  child: Container(
-                    margin: const EdgeInsets.all(3),
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      gradient: LinearGradient(
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                        colors: [palette.bg, palette.primary, palette.secondary],
-                      ),
-                    ),
-                    child: isSelected
-                        ? const Icon(Icons.check, color: Colors.white, size: 18)
-                        : null,
-                  ),
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  _themeName(theme),
-                  style: TextStyle(
-                    color: isSelected ? AppColors.textPrimary : AppColors.textHint,
-                    fontSize: 11,
-                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                  ),
-                ),
-              ],
-            ),
-          );
-        }).toList(),
+    return Text(
+      text,
+      style: TextStyle(
+        color: AppColors.textHint,
+        fontSize: 11,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 1.4,
       ),
     );
   }
+}
 
-  String _themeName(AppColorTheme theme) {
-    switch (theme) {
-      case AppColorTheme.dark:
-        return '다크';
-      case AppColorTheme.cream:
-        return '크림';
-      case AppColorTheme.lavender:
-        return '라벤더';
-      case AppColorTheme.tossBlue:
-        return '블루';
-    }
+/// 항목들을 하나의 카드로 묶어주는 그룹
+class _MenuGroup extends StatelessWidget {
+  final List<_MenuItem> items;
+  const _MenuGroup({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.darkCard,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(children: items),
+    );
+  }
+}
+
+class _MenuItem extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final bool destructive;
+  final bool accent;
+  final bool isLast;
+
+  const _MenuItem({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.destructive = false,
+    this.accent = false,
+    this.isLast = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = destructive
+        ? AppColors.error
+        : accent
+            ? AppColors.neonOrange
+            : AppColors.textPrimary;
+
+    return Column(
+      children: [
+        InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(14),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 15),
+            child: Row(
+              children: [
+                Icon(icon, color: color, size: 20),
+                const SizedBox(width: 14),
+                Text(
+                  label,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const Spacer(),
+                if (!destructive)
+                  Icon(Icons.chevron_right_rounded,
+                      color: AppColors.textHint, size: 18),
+              ],
+            ),
+          ),
+        ),
+        if (!isLast)
+          Divider(
+            height: 1,
+            indent: 50,
+            color: AppColors.darkDivider,
+          ),
+      ],
+    );
   }
 }
 
@@ -313,17 +344,12 @@ class _AppVersionInfo extends StatelessWidget {
   Widget build(BuildContext context) {
     return FutureBuilder<PackageInfo>(
       future: PackageInfo.fromPlatform(),
-      builder: (context, snapshot) {
+      builder: (_, snapshot) {
         final version = snapshot.data?.version ?? '-';
-        final buildNumber = snapshot.data?.buildNumber ?? '-';
-        return Center(
-          child: Text(
-            '핀로그 v$version ($buildNumber)',
-            style: TextStyle(
-              color: AppColors.textHint,
-              fontSize: 12,
-            ),
-          ),
+        final build = snapshot.data?.buildNumber ?? '-';
+        return Text(
+          '핀로그 v$version ($build)',
+          style: TextStyle(color: AppColors.textHint, fontSize: 12),
         );
       },
     );

--- a/lib/features/settings/presentation/pages/theme_selection_page.dart
+++ b/lib/features/settings/presentation/pages/theme_selection_page.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/app/theme/color_themes.dart';
+import 'package:bowling_diary/shared/providers/theme_provider.dart';
+
+class ThemeSelectionPage extends ConsumerWidget {
+  const ThemeSelectionPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentTheme = ref.watch(colorThemeProvider);
+    final currentBrightness = ref.watch(platformBrightnessProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('테마')),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          Text(
+            '디바이스 다크모드에 따라 자동으로 색상이 변경됩니다.',
+            style: AppTextStyles.bodySmall
+                .copyWith(color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: 20),
+          ...AppColorTheme.values.map((theme) {
+            final isSelected = theme == currentTheme;
+            final lightPalette = ColorThemes.previewLight(theme);
+            final darkPalette = ColorThemes.previewDark(theme);
+            final activePalette = ColorThemes.palette(theme, currentBrightness);
+
+            return GestureDetector(
+              onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                margin: const EdgeInsets.only(bottom: 12),
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: AppColors.darkCard,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                    color: isSelected
+                        ? activePalette.primary
+                        : AppColors.darkDivider,
+                    width: isSelected ? 1.5 : 1,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    // 라이트/다크 미리보기 원 2개
+                    Row(
+                      children: [
+                        _PreviewCircle(palette: lightPalette, label: '라이트'),
+                        const SizedBox(width: 8),
+                        _PreviewCircle(palette: darkPalette, label: '다크'),
+                      ],
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            _themeName(theme),
+                            style: TextStyle(
+                              color: AppColors.textPrimary,
+                              fontSize: 15,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            _themeDesc(theme),
+                            style: AppTextStyles.bodySmall.copyWith(
+                              color: AppColors.textHint,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (isSelected)
+                      Icon(Icons.check_rounded,
+                          color: activePalette.primary, size: 20),
+                  ],
+                ),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  String _themeName(AppColorTheme theme) {
+    switch (theme) {
+      case AppColorTheme.blue:
+        return '블루';
+      case AppColorTheme.cream:
+        return '크림';
+      case AppColorTheme.lavender:
+        return '라벤더';
+    }
+  }
+
+  String _themeDesc(AppColorTheme theme) {
+    switch (theme) {
+      case AppColorTheme.blue:
+        return '깔끔하고 신뢰감 있는 블루 계열';
+      case AppColorTheme.cream:
+        return '따뜻하고 아늑한 크림 계열';
+      case AppColorTheme.lavender:
+        return '부드럽고 감각적인 라벤더 계열';
+    }
+  }
+}
+
+class _PreviewCircle extends StatelessWidget {
+  final ColorPalette palette;
+  final String label;
+
+  const _PreviewCircle({required this.palette, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [palette.bg, palette.card, palette.primary],
+            ),
+            border: Border.all(
+              color: Colors.black.withValues(alpha: 0.1),
+              width: 0.5,
+            ),
+          ),
+          child: Center(
+            child: Container(
+              width: 14,
+              height: 14,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: palette.primary,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 9,
+            color: AppColors.textHint,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/presentation/pages/theme_selection_page.dart
+++ b/lib/features/settings/presentation/pages/theme_selection_page.dart
@@ -35,7 +35,7 @@ class ThemeSelectionPage extends ConsumerWidget {
             return GestureDetector(
               onTap: () async {
                 await ref.read(colorThemeProvider.notifier).setTheme(theme);
-                if (context.mounted) AppRestarter.of(context).restart();
+                if (context.mounted) await AppRestarter.of(context).restart();
               },
               child: AnimatedContainer(
                 duration: const Duration(milliseconds: 200),

--- a/lib/features/settings/presentation/pages/theme_selection_page.dart
+++ b/lib/features/settings/presentation/pages/theme_selection_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/color_themes.dart';
+import 'package:bowling_diary/shared/providers/theme_provider.dart';
+
+class ThemeSelectionPage extends ConsumerWidget {
+  const ThemeSelectionPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentTheme = ref.watch(colorThemeProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('테마')),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: AppColorTheme.values.map((theme) {
+          final palette = ColorThemes.fromTheme(theme);
+          final isSelected = theme == currentTheme;
+
+          return GestureDetector(
+            onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              margin: const EdgeInsets.only(bottom: 12),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: AppColors.darkCard,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: isSelected
+                      ? palette.primary
+                      : AppColors.darkDivider,
+                  width: isSelected ? 1.5 : 1,
+                ),
+              ),
+              child: Row(
+                children: [
+                  // 테마 미리보기 원
+                  Container(
+                    width: 44,
+                    height: 44,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient: LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [
+                          palette.bg,
+                          palette.primary,
+                          palette.secondary,
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Text(
+                    _themeName(theme),
+                    style: TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const Spacer(),
+                  if (isSelected)
+                    Icon(Icons.check_rounded,
+                        color: palette.primary, size: 20),
+                ],
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  String _themeName(AppColorTheme theme) {
+    switch (theme) {
+      case AppColorTheme.dark:
+        return '다크';
+      case AppColorTheme.cream:
+        return '크림';
+      case AppColorTheme.lavender:
+        return '라벤더';
+      case AppColorTheme.tossBlue:
+        return '블루';
+    }
+  }
+}

--- a/lib/features/settings/presentation/pages/theme_selection_page.dart
+++ b/lib/features/settings/presentation/pages/theme_selection_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:bowling_diary/app/app.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/app/theme/color_themes.dart';
@@ -11,7 +12,8 @@ class ThemeSelectionPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currentTheme = ref.watch(colorThemeProvider);
-    final currentBrightness = ref.watch(platformBrightnessProvider);
+    final currentBrightness =
+        WidgetsBinding.instance.platformDispatcher.platformBrightness;
 
     return Scaffold(
       appBar: AppBar(title: const Text('테마')),
@@ -31,7 +33,10 @@ class ThemeSelectionPage extends ConsumerWidget {
             final activePalette = ColorThemes.palette(theme, currentBrightness);
 
             return GestureDetector(
-              onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
+              onTap: () async {
+                await ref.read(colorThemeProvider.notifier).setTheme(theme);
+                if (context.mounted) AppRestarter.of(context).restart();
+              },
               child: AnimatedContainer(
                 duration: const Duration(milliseconds: 200),
                 margin: const EdgeInsets.only(bottom: 12),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:bowling_diary/app/app.dart';
+import 'package:bowling_diary/app/app.dart' show AppRestarter, preloadTheme;
 import 'package:bowling_diary/core/constants/supabase_constants.dart';
 
 void main() async {
@@ -17,6 +16,7 @@ void main() async {
     anonKey: SupabaseConstants.anonKey,
   );
 
+  await preloadTheme(); // 첫 프레임 전에 팔레트 세팅
   FlutterNativeSplash.remove();
 
   runApp(const AppRestarter());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,9 +19,5 @@ void main() async {
 
   FlutterNativeSplash.remove();
 
-  runApp(
-    const ProviderScope(
-      child: BowlingDiaryApp(),
-    ),
-  );
+  runApp(const AppRestarter());
 }

--- a/lib/shared/providers/theme_provider.dart
+++ b/lib/shared/providers/theme_provider.dart
@@ -4,38 +4,43 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/color_themes.dart';
 
-final colorThemeProvider = StateNotifierProvider<ColorThemeNotifier, AppColorTheme>((ref) {
+/// 사용자가 선택한 테마 스타일 (3종)
+final colorThemeProvider =
+    StateNotifierProvider<ColorThemeNotifier, AppColorTheme>((ref) {
   return ColorThemeNotifier();
 });
 
-final themeProvider = Provider<ThemeMode>((ref) {
-  final colorTheme = ref.watch(colorThemeProvider);
-  final palette = ColorThemes.fromTheme(colorTheme);
-  return palette.brightness == Brightness.light ? ThemeMode.light : ThemeMode.dark;
+/// 디바이스 밝기 — app.dart의 WidgetsBindingObserver가 업데이트
+final platformBrightnessProvider =
+    StateProvider<Brightness>((ref) {
+  return WidgetsBinding.instance.platformDispatcher.platformBrightness;
+});
+
+/// 현재 활성 팔레트 (테마 + 밝기 조합)
+final activePaletteProvider = Provider<ColorPalette>((ref) {
+  final theme = ref.watch(colorThemeProvider);
+  final brightness = ref.watch(platformBrightnessProvider);
+  final palette = ColorThemes.palette(theme, brightness);
+  AppColors.setPalette(palette);
+  return palette;
 });
 
 class ColorThemeNotifier extends StateNotifier<AppColorTheme> {
-  ColorThemeNotifier() : super(AppColorTheme.cream) {
+  ColorThemeNotifier() : super(AppColorTheme.blue) {
     _load();
   }
 
-  static const _key = 'color_theme';
+  static const _key = 'color_theme_v2';
 
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
     final idx = prefs.getInt(_key);
     if (idx != null && idx >= 0 && idx < AppColorTheme.values.length) {
-      final theme = AppColorTheme.values[idx];
-      AppColors.setPalette(ColorThemes.fromTheme(theme));
-      state = theme;
-    } else {
-      AppColors.setPalette(ColorThemes.cream);
-      state = AppColorTheme.cream;
+      state = AppColorTheme.values[idx];
     }
   }
 
   Future<void> setTheme(AppColorTheme theme) async {
-    AppColors.setPalette(ColorThemes.fromTheme(theme));
     state = theme;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_key, theme.index);

--- a/lib/shared/providers/theme_provider.dart
+++ b/lib/shared/providers/theme_provider.dart
@@ -4,25 +4,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/color_themes.dart';
 
-/// 사용자가 선택한 테마 스타일 (3종)
 final colorThemeProvider =
     StateNotifierProvider<ColorThemeNotifier, AppColorTheme>((ref) {
   return ColorThemeNotifier();
-});
-
-/// 디바이스 밝기 — app.dart의 WidgetsBindingObserver가 업데이트
-final platformBrightnessProvider =
-    StateProvider<Brightness>((ref) {
-  return WidgetsBinding.instance.platformDispatcher.platformBrightness;
-});
-
-/// 현재 활성 팔레트 (테마 + 밝기 조합)
-final activePaletteProvider = Provider<ColorPalette>((ref) {
-  final theme = ref.watch(colorThemeProvider);
-  final brightness = ref.watch(platformBrightnessProvider);
-  final palette = ColorThemes.palette(theme, brightness);
-  AppColors.setPalette(palette);
-  return palette;
 });
 
 class ColorThemeNotifier extends StateNotifier<AppColorTheme> {
@@ -35,11 +19,18 @@ class ColorThemeNotifier extends StateNotifier<AppColorTheme> {
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
     final idx = prefs.getInt(_key);
-    if (idx != null && idx >= 0 && idx < AppColorTheme.values.length) {
-      state = AppColorTheme.values[idx];
-    }
+    final theme = (idx != null && idx >= 0 && idx < AppColorTheme.values.length)
+        ? AppColorTheme.values[idx]
+        : AppColorTheme.blue;
+
+    // 앱 시작 시 디바이스 밝기 한 번 감지
+    final brightness =
+        WidgetsBinding.instance.platformDispatcher.platformBrightness;
+    AppColors.setPalette(ColorThemes.palette(theme, brightness));
+    state = theme;
   }
 
+  /// 테마 저장 후 앱을 재시작해야 실제로 적용됨
   Future<void> setTheme(AppColorTheme theme) async {
     state = theme;
     final prefs = await SharedPreferences.getInstance();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -433,6 +433,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffmpeg_kit_flutter_new:
+    dependency: "direct main"
+    description:
+      name: ffmpeg_kit_flutter_new
+      sha256: d127635f27e93a7f21f0a14ce0a1a148e80919c402dac4a2118d73bfb17ce841
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
+  ffmpeg_kit_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: ffmpeg_kit_flutter_platform_interface
+      sha256: addf046ae44e190ad0101b2fde2ad909a3cd08a2a109f6106d2f7048b7abedee
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   file:
     dependency: transitive
     description:
@@ -1009,7 +1025,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   fl_chart: ^0.69.0
 
   # 이미지
-  image_picker: ^1.1.2
+  image_picker: ^1.2.1
   cached_network_image: ^3.4.1
 
   # 유틸리티
@@ -45,6 +45,8 @@ dependencies:
   image: ^4.5.3
   camera: ^0.12.0+1
   video_player: ^2.11.1
+  ffmpeg_kit_flutter_new: ^4.1.0
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,3 +88,4 @@ flutter:
     - assets/
     - assets/icon/
     - assets/splash/
+    - assets/videos/


### PR DESCRIPTION
## Summary
- 카메라 화면 좌하단에 갤러리 버튼 추가
- 갤러리에서 동영상 선택 시 `ffmpeg`으로 프레임 추출 (10fps 샘플링)
- 기존 볼 트래킹 알고리즘 그대로 적용 → 속도·RPM 측정 가능
- iOS 사진 라이브러리 권한(`NSPhotoLibraryUsageDescription`) 추가

## 신규 파일
- `video_frame_extractor_service.dart` — ffmpeg 프레임 추출 + 원본 fps 감지

## 변경 파일
- `video_analysis_service.dart` — `analyzeImages()` 메서드 추가, `_estimateRpm` sampleInterval 파라미터화
- `analysis_camera_page.dart` — 갤러리 버튼 + `_pickFromGallery()` 로직 추가

## Test plan
- [ ] 카메라 화면에서 갤러리 버튼 표시 확인 (녹화 중엔 숨김)
- [ ] 갤러리 동영상 선택 → 분석 로딩 → 결과 화면 확인
- [ ] 속도·RPM 결과값 표시 확인
- [ ] 직접 촬영 기능 정상 동작 확인 (기존 기능 회귀 없음)