### PR TITLE
feat: 볼 분석 탭 전체 구현 (Gemini 분석, UI 개편, 삭제)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,6 +45,8 @@
 	<string>볼링 점수판 촬영 및 투구 영상 녹화에 카메라 접근이 필요합니다</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>영상 녹화를 위해 마이크 접근이 필요합니다</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>갤러리 영상을 불러와 볼링공 속도·RPM을 분석합니다</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/features/analysis/data/services/video_analysis_service.dart
+++ b/lib/features/analysis/data/services/video_analysis_service.dart
@@ -77,6 +77,66 @@ class VideoAnalysisService {
     );
   }
 
+  /// 갤러리 영상 프레임(img.Image) 분석 — sampleFps는 추출 시 사용한 fps
+  AnalysisData analyzeImages(
+    List<img.Image> frames,
+    int originalFps, {
+    int sampleFps = 10,
+  }) {
+    debugPrint('[Analysis] 갤러리 분석 시작: ${frames.length}개 프레임, 원본 ${originalFps}fps, 샘플 ${sampleFps}fps');
+
+    if (frames.length < 5) {
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frames.length, fpsUsed: originalFps);
+    }
+
+    final positions = <_BallPosition?>[];
+    img.Image? prevGray;
+
+    for (final frame in frames) {
+      final gray = img.grayscale(frame);
+      if (prevGray != null) {
+        positions.add(_detectBallByMotion(prevGray, gray));
+      } else {
+        positions.add(null);
+      }
+      prevGray = gray;
+    }
+
+    final detected = positions.asMap().entries.where((e) => e.value != null).toList();
+
+    if (detected.length < 3) {
+      debugPrint('[Analysis] 볼 감지 실패 → 속도 0 반환');
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frames.length, fpsUsed: originalFps);
+    }
+
+    final releaseIdx = detected.first.key;
+    final impactIdx = detected.last.key;
+    final sampleInterval = (originalFps / sampleFps).round().clamp(1, 999);
+    final actualFrameCount = (impactIdx - releaseIdx) * sampleInterval;
+    final elapsedSec = actualFrameCount / originalFps;
+
+    if (elapsedSec <= 0) {
+      return AnalysisData(speedKmh: 0, framesAnalyzed: frames.length, fpsUsed: originalFps);
+    }
+
+    final speedKmh = (_laneLength / elapsedSec) * 3.6;
+    debugPrint('[Analysis] 속도: ${speedKmh.toStringAsFixed(1)}km/h');
+
+    final rpm = _estimateRpm(
+      detected.map((e) => e.value!).toList(),
+      originalFps,
+      sampleInterval: sampleInterval,
+    );
+    debugPrint('[Analysis] RPM 추정: $rpm');
+
+    return AnalysisData(
+      speedKmh: double.parse(speedKmh.toStringAsFixed(1)),
+      rpmEstimated: rpm,
+      framesAnalyzed: frames.length,
+      fpsUsed: originalFps,
+    );
+  }
+
   /// CameraImage(YUV420) → 그레이스케일 (Y 채널만 사용)
   img.Image? _toGrayscale(CameraImage frame) {
     try {
@@ -123,7 +183,11 @@ class VideoAnalysisService {
   }
 
   /// 볼의 X 좌표 진동 주기로 RPM 추정
-  int? _estimateRpm(List<_BallPosition> positions, int fps) {
+  int? _estimateRpm(
+    List<_BallPosition> positions,
+    int fps, {
+    int sampleInterval = 10,
+  }) {
     if (positions.length < 4) return null;
 
     int directionChanges = 0;
@@ -135,14 +199,13 @@ class VideoAnalysisService {
       if (dx.abs() > 1) prevDx = dx;
     }
 
-    final sampleFps = fps / 10.0;
-    final durationSec = positions.length / sampleFps;
+    final effectiveFps = fps / sampleInterval;
+    final durationSec = positions.length / effectiveFps;
     if (durationSec <= 0) return null;
 
     final rotationsPerSec = directionChanges / 2.0 / durationSec;
     final rpm = (rotationsPerSec * 60).round();
 
-    // 볼링 RPM 현실 범위 벗어나면 null
     if (rpm < 100 || rpm > 500) return null;
     return rpm;
   }

--- a/lib/features/analysis/data/services/video_frame_extractor_service.dart
+++ b/lib/features/analysis/data/services/video_frame_extractor_service.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_new/ffprobe_kit.dart';
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+import 'package:path_provider/path_provider.dart';
+
+class FrameExtractionResult {
+  final List<img.Image> frames;
+  final int originalFps;
+
+  const FrameExtractionResult({
+    required this.frames,
+    required this.originalFps,
+  });
+}
+
+class VideoFrameExtractorService {
+  static const _sampleFps = 10;
+
+  Future<FrameExtractionResult> extract(String videoPath) async {
+    final originalFps = await _getVideoFps(videoPath);
+
+    final tempDir = await getTemporaryDirectory();
+    final framesDir = Directory(
+      '${tempDir.path}/frames_${DateTime.now().millisecondsSinceEpoch}',
+    );
+    await framesDir.create();
+
+    try {
+      final outputPattern = '${framesDir.path}/frame_%04d.jpg';
+      final session = await FFmpegKit.execute(
+        '-i "$videoPath" -vf fps=$_sampleFps -q:v 2 "$outputPattern"',
+      );
+      final returnCode = await session.getReturnCode();
+
+      if (returnCode == null || !returnCode.isValueSuccess()) {
+        final logs = await session.getLogs();
+        debugPrint('[FrameExtractor] ffmpeg 오류: ${logs.map((l) => l.getMessage()).join('\n')}');
+        throw Exception('프레임 추출 실패 (returnCode: $returnCode)');
+      }
+
+      final frameFiles = framesDir.listSync()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+      final frames = <img.Image>[];
+      for (final file in frameFiles) {
+        if (file is File && file.path.endsWith('.jpg')) {
+          final bytes = await file.readAsBytes();
+          final image = img.decodeImage(bytes);
+          if (image != null) frames.add(image);
+        }
+      }
+
+      debugPrint('[FrameExtractor] 추출 완료: ${frames.length}개 프레임, 원본 ${originalFps}fps');
+      return FrameExtractionResult(frames: frames, originalFps: originalFps);
+    } finally {
+      await framesDir.delete(recursive: true);
+    }
+  }
+
+  Future<int> _getVideoFps(String videoPath) async {
+    try {
+      final session = await FFprobeKit.getMediaInformation(videoPath);
+      final streams = session.getMediaInformation()?.getStreams();
+      if (streams != null) {
+        for (final stream in streams) {
+          if (stream.getType() == 'video') {
+            final fpsStr = stream.getAverageFrameRate(); // "60/1" 형태
+            if (fpsStr != null) {
+              final parts = fpsStr.split('/');
+              if (parts.length == 2) {
+                final num = int.tryParse(parts[0]) ?? 30;
+                final den = int.tryParse(parts[1]) ?? 1;
+                return den > 0 ? (num / den).round() : 30;
+              }
+            }
+          }
+        }
+      }
+    } catch (e) {
+      debugPrint('[FrameExtractor] fps 감지 실패: $e');
+    }
+    return 30;
+  }
+}

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -1,9 +1,11 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/features/analysis/data/services/camera_recording_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/camera_guide_overlay.dart';
 
@@ -17,6 +19,7 @@ class AnalysisCameraPage extends StatefulWidget {
 class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
   final _cameraService = CameraRecordingService();
   final _analysisService = VideoAnalysisService();
+  final _frameExtractor = VideoFrameExtractorService();
 
   CameraController? _controller;
   bool _isInitialized = false;
@@ -51,6 +54,40 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
       await _cameraService.startRecording();
       if (!mounted) return;
       setState(() => _isRecording = true);
+    }
+  }
+
+  Future<void> _pickFromGallery() async {
+    final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
+    if (video == null || !mounted) return;
+
+    setState(() => _isAnalyzing = true);
+    try {
+      final result = await _frameExtractor.extract(video.path);
+      final analysisData = _analysisService.analyzeImages(
+        result.frames,
+        result.originalFps,
+      );
+
+      if (!mounted) return;
+      setState(() => _isAnalyzing = false);
+
+      await Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => AnalysisResultPage(
+            analysisData: analysisData,
+            videoPath: video.path,
+            recordedAt: DateTime.now(),
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isAnalyzing = false;
+        _error = '갤러리 영상 분석 오류: $e';
+      });
     }
   }
 
@@ -157,10 +194,31 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
             right: 40,
             child: Text(
               '${_cameraService.fps}fps',
-              style:
-                  AppTextStyles.bodySmall.copyWith(color: Colors.white70),
+              style: AppTextStyles.bodySmall.copyWith(color: Colors.white70),
             ),
           ),
+          if (!_isRecording)
+            Positioned(
+              bottom: 68,
+              left: 40,
+              child: GestureDetector(
+                onTap: _pickFromGallery,
+                child: Container(
+                  width: 56,
+                  height: 56,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Colors.black45,
+                    border: Border.all(color: Colors.white54, width: 1.5),
+                  ),
+                  child: const Icon(
+                    Icons.photo_library_outlined,
+                    color: Colors.white,
+                    size: 26,
+                  ),
+                ),
+              ),
+            ),
         ],
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -433,6 +433,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffmpeg_kit_flutter_new:
+    dependency: "direct main"
+    description:
+      name: ffmpeg_kit_flutter_new
+      sha256: d127635f27e93a7f21f0a14ce0a1a148e80919c402dac4a2118d73bfb17ce841
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
+  ffmpeg_kit_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: ffmpeg_kit_flutter_platform_interface
+      sha256: addf046ae44e190ad0101b2fde2ad909a3cd08a2a109f6106d2f7048b7abedee
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   file:
     dependency: transitive
     description:
@@ -1009,7 +1025,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   fl_chart: ^0.69.0
 
   # 이미지
-  image_picker: ^1.1.2
+  image_picker: ^1.2.1
   cached_network_image: ^3.4.1
 
   # 유틸리티
@@ -45,6 +45,8 @@ dependencies:
   image: ^4.5.3
   camera: ^0.12.0+1
   video_player: ^2.11.1
+  ffmpeg_kit_flutter_new: ^4.1.0
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- 갤러리 영상 불러오기 + 직접 촬영 선택 화면
- Gemini File API 기반 구속·RPM 분석 (로컬 알고리즘 fallback)
- 영상 구간 선택(트림) 후 분석 → 정확도 향상
- 분석 로딩 화면: 선택한 영상 배경 재생
- 결과 화면: 풀스크린 영상 + 하단 슬라이드업 수치 오버레이
- 히스토리 카드 리디자인 + 디테일 화면 추가
- 스와이프 삭제 (낙관적 업데이트)
- iOS 사진 라이브러리 권한 추가
- Supabase ball_analysis 테이블 delete 메서드 추가

## Packages added
- `ffmpeg_kit_flutter_new`
- `path_provider`
- `image_picker` (direct dep)

## Note
`main` CI/CD 트리거 방지를 위해 `dev` 브랜치로 PR 올립니다.