### PR TITLE
feat: 마이페이지 개편, GoRouter 통합, 테마 수정

### DIFF
--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -14,6 +14,10 @@ import 'package:bowling_diary/features/balls/presentation/pages/balls_page.dart'
 import 'package:bowling_diary/features/settings/presentation/pages/settings_page.dart';
 import 'package:bowling_diary/features/admin/presentation/pages/catalog_manage_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_tab_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_camera_page.dart';
+import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
+import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
   final authState = ref.watch(authNotifierProvider);
@@ -86,6 +90,26 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/admin/catalog',
         builder: (context, state) => const CatalogManagePage(),
+      ),
+      // 분석 플로우 — 바텀 네비게이션 없음
+      GoRoute(
+        path: '/analysis/guide',
+        builder: (context, state) => const AnalysisGuidePage(),
+      ),
+      GoRoute(
+        path: '/analysis/camera',
+        builder: (context, state) => const AnalysisCameraPage(),
+      ),
+      GoRoute(
+        path: '/analysis/result',
+        builder: (context, state) {
+          final extra = state.extra as Map<String, dynamic>;
+          return AnalysisResultPage(
+            analysisData: extra['analysisData'] as AnalysisData,
+            videoPath: extra['videoPath'] as String,
+            recordedAt: extra['recordedAt'] as DateTime,
+          );
+        },
       ),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) {

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -80,6 +80,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         },
       ),
       GoRoute(
+        path: '/balls',
+        builder: (context, state) => const BallsPage(),
+      ),
+      GoRoute(
         path: '/admin/catalog',
         builder: (context, state) => const CatalogManagePage(),
       ),
@@ -109,14 +113,6 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: '/analysis',
                 builder: (context, state) => const AnalysisTabPage(),
-              ),
-            ],
-          ),
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/balls',
-                builder: (context, state) => const BallsPage(),
               ),
             ],
           ),
@@ -172,14 +168,9 @@ class ScaffoldWithNavBar extends StatelessWidget {
               label: '분석',
             ),
             BottomNavigationBarItem(
-              icon: Icon(Icons.sports_baseball_outlined),
-              activeIcon: Icon(Icons.sports_baseball),
-              label: '내 볼',
-            ),
-            BottomNavigationBarItem(
               icon: Icon(Icons.person_outline),
               activeIcon: Icon(Icons.person),
-              label: '설정',
+              label: '마이페이지',
             ),
           ],
         ),

--- a/lib/features/analysis/presentation/pages/analysis_camera_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_camera_page.dart
@@ -1,12 +1,12 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/features/analysis/data/services/camera_recording_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_analysis_service.dart';
 import 'package:bowling_diary/features/analysis/data/services/video_frame_extractor_service.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/camera_guide_overlay.dart';
 
 class AnalysisCameraPage extends StatefulWidget {
@@ -72,16 +72,12 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
       if (!mounted) return;
       setState(() => _isAnalyzing = false);
 
-      await Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (_) => AnalysisResultPage(
-            analysisData: analysisData,
-            videoPath: video.path,
-            recordedAt: DateTime.now(),
-          ),
-        ),
-      );
+      if (!mounted) return;
+      context.pushReplacement('/analysis/result', extra: {
+        'analysisData': analysisData,
+        'videoPath': video.path,
+        'recordedAt': DateTime.now(),
+      });
     } catch (e) {
       if (!mounted) return;
       setState(() {
@@ -105,16 +101,12 @@ class _AnalysisCameraPageState extends State<AnalysisCameraPage> {
       if (!mounted) return;
       setState(() => _isAnalyzing = false);
 
-      await Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (_) => AnalysisResultPage(
-            analysisData: analysisData,
-            videoPath: session.videoPath,
-            recordedAt: DateTime.now(),
-          ),
-        ),
-      );
+      if (!mounted) return;
+      context.pushReplacement('/analysis/result', extra: {
+        'analysisData': analysisData,
+        'videoPath': session.videoPath,
+        'recordedAt': DateTime.now(),
+      });
     } catch (e) {
       if (!mounted) return;
       setState(() {

--- a/lib/features/analysis/presentation/pages/analysis_guide_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_guide_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_camera_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/bowling_pin_character.dart';
 
 class AnalysisGuidePage extends StatefulWidget {
@@ -96,11 +96,7 @@ class _AnalysisGuidePageState extends State<AnalysisGuidePage> {
                           curve: Curves.easeInOut,
                         );
                       } else {
-                        Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(
-                              builder: (_) => const AnalysisCameraPage()),
-                        );
+                        context.pushReplacement('/analysis/camera');
                       }
                     },
                     child: Text(

--- a/lib/features/analysis/presentation/pages/analysis_result_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_result_page.dart
@@ -2,6 +2,7 @@ import 'dart:io' as dart_io;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:uuid/uuid.dart';
 import 'package:video_player/video_player.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
@@ -67,10 +68,11 @@ class _AnalysisResultPageState extends ConsumerState<AnalysisResultPage> {
     );
 
     await ref.read(analysisRepositoryProvider).save(entity);
+    ref.invalidate(analysisHistoryProvider);
 
     if (!mounted) return;
     setState(() => _isSaving = false);
-    Navigator.of(context).popUntil((r) => r.isFirst);
+    context.go('/analysis');
   }
 
   Future<void> _onSavePressed() async {

--- a/lib/features/analysis/presentation/pages/analysis_tab_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_tab_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/providers/analysis_provider.dart';
 import 'package:bowling_diary/features/analysis/presentation/widgets/analysis_history_card.dart';
 import 'package:bowling_diary/shared/widgets/loading_widget.dart';
@@ -47,9 +47,7 @@ class AnalysisTabPage extends ConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton(
         backgroundColor: AppColors.neonOrange,
-        onPressed: () => Navigator.of(context, rootNavigator: true).push(
-          MaterialPageRoute(builder: (_) => const AnalysisGuidePage()),
-        ).then((_) => ref.invalidate(analysisHistoryProvider)),
+        onPressed: () => context.push('/analysis/guide'),
         child: const Icon(Icons.videocam, color: Colors.black),
       ),
     );

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/shared/providers/theme_provider.dart';
 import 'package:bowling_diary/features/auth/presentation/providers/auth_provider.dart';
 import 'package:bowling_diary/features/settings/presentation/pages/theme_selection_page.dart';
 
@@ -12,6 +13,7 @@ class SettingsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(colorThemeProvider);
     final user = ref.watch(currentUserProvider);
     final isAdmin = user?.isAdmin ?? false;
 

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -4,9 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
-import 'package:bowling_diary/app/theme/color_themes.dart';
 import 'package:bowling_diary/features/auth/presentation/providers/auth_provider.dart';
-import 'package:bowling_diary/shared/providers/theme_provider.dart';
+import 'package:bowling_diary/features/settings/presentation/pages/theme_selection_page.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -17,132 +16,100 @@ class SettingsPage extends ConsumerWidget {
     final isAdmin = user?.isAdmin ?? false;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('설정')),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          // 프로필 카드
-          Container(
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              color: AppColors.darkCard,
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: AppColors.darkDivider),
-            ),
-            child: Row(
-              children: [
-                CircleAvatar(
-                  radius: 28,
-                  backgroundColor: AppColors.neonOrange.withValues(alpha: 0.15),
-                  child: Text(
-                    (user?.nickname ?? '?')[0].toUpperCase(),
-                    style: TextStyle(color: AppColors.neonOrange, fontSize: 22, fontWeight: FontWeight.w800),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(user?.nickname ?? '닉네임 없음', style: AppTextStyles.labelLarge),
-                      const SizedBox(height: 4),
-                      Row(
-                        children: [
-                          if (user?.bowlingStyle != null && user!.bowlingStyle!.isNotEmpty)
-                            Text(user.bowlingStyle!, style: AppTextStyles.bodySmall),
-                          if (isAdmin) ...[
-                            const SizedBox(width: 8),
-                            Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                              decoration: BoxDecoration(
-                                color: AppColors.neonOrange.withValues(alpha: 0.15),
-                                borderRadius: BorderRadius.circular(4),
-                              ),
-                              child: Text('관리자', style: TextStyle(color: AppColors.neonOrange, fontSize: 10, fontWeight: FontWeight.w700)),
-                            ),
-                          ],
-                        ],
+      backgroundColor: AppColors.darkBg,
+      body: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(child: _ProfileHeader(user: user, isAdmin: isAdmin)),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 28, 20, 0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 관리자
+                  if (isAdmin) ...[
+                    _SectionLabel('관리자'),
+                    const SizedBox(height: 8),
+                    _MenuItem(
+                      icon: Icons.sports_baseball_outlined,
+                      label: '카탈로그 관리',
+                      onTap: () => context.push('/admin/catalog'),
+                      accent: true,
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+
+                  // 내 정보
+                  _SectionLabel('내 정보'),
+                  const SizedBox(height: 8),
+                  _MenuGroup(items: [
+                    _MenuItem(
+                      icon: Icons.sports_baseball_outlined,
+                      label: '내 볼',
+                      onTap: () => context.push('/balls'),
+                    ),
+                    _MenuItem(
+                      icon: Icons.edit_outlined,
+                      label: '프로필 수정',
+                      onTap: () => context.push('/profile-setup'),
+                      isLast: true,
+                    ),
+                  ]),
+                  const SizedBox(height: 24),
+
+                  // 앱 설정
+                  _SectionLabel('앱 설정'),
+                  const SizedBox(height: 8),
+                  _MenuGroup(items: [
+                    _MenuItem(
+                      icon: Icons.palette_outlined,
+                      label: '테마',
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => const ThemeSelectionPage()),
                       ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 24),
+                      isLast: true,
+                    ),
+                  ]),
+                  const SizedBox(height: 24),
 
-          // 관리자 섹션
-          if (isAdmin) ...[
-            Text('관리자', style: AppTextStyles.labelSmall.copyWith(color: AppColors.neonOrange)),
-            const SizedBox(height: 8),
-            _SettingsTile(
-              icon: Icons.sports_baseball,
-              title: '카탈로그 관리',
-              subtitle: '볼링볼 카탈로그 추가/수정/삭제',
-              onTap: () => context.push('/admin/catalog'),
-            ),
-            const SizedBox(height: 24),
-          ],
+                  // 계정
+                  _SectionLabel('계정'),
+                  const SizedBox(height: 8),
+                  _MenuGroup(items: [
+                    _MenuItem(
+                      icon: Icons.logout_rounded,
+                      label: '로그아웃',
+                      onTap: () =>
+                          ref.read(authNotifierProvider.notifier).signOut(),
+                    ),
+                    _MenuItem(
+                      icon: Icons.delete_outline_rounded,
+                      label: '회원 탈퇴',
+                      onTap: () => _confirmDeleteAccount(context, ref),
+                      destructive: true,
+                      isLast: true,
+                    ),
+                  ]),
+                  const SizedBox(height: 40),
 
-          // 테마 섹션
-          Text('테마', style: AppTextStyles.labelSmall),
-          const SizedBox(height: 8),
-          _ColorThemeSelector(ref: ref),
-          const SizedBox(height: 24),
-
-          // 일반 섹션
-          Text('일반', style: AppTextStyles.labelSmall),
-          const SizedBox(height: 8),
-          _SettingsTile(
-            icon: Icons.person_outline,
-            title: '프로필 수정',
-            subtitle: '닉네임, 투구 스타일 변경',
-            onTap: () => context.push('/profile-setup'),
-          ),
-          const SizedBox(height: 32),
-
-          // 계정 섹션
-          Text('계정', style: AppTextStyles.labelSmall),
-          const SizedBox(height: 8),
-          SizedBox(
-            width: double.infinity,
-            height: 48,
-            child: OutlinedButton(
-              onPressed: () => ref.read(authNotifierProvider.notifier).signOut(),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: AppColors.textSecondary,
-                side: BorderSide(color: AppColors.darkDivider),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  Center(child: _AppVersionInfo()),
+                  const SizedBox(height: 32),
+                ],
               ),
-              child: const Text('로그아웃'),
             ),
           ),
-          const SizedBox(height: 12),
-          SizedBox(
-            width: double.infinity,
-            height: 48,
-            child: OutlinedButton(
-              onPressed: () => _confirmDeleteAccount(context, ref),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: AppColors.error,
-                side: BorderSide(color: AppColors.error),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-              ),
-              child: const Text('회원 탈퇴'),
-            ),
-          ),
-          const SizedBox(height: 32),
-          _AppVersionInfo(),
-          const SizedBox(height: 24),
         ],
       ),
     );
   }
 
   Future<void> _confirmDeleteAccount(BuildContext context, WidgetRef ref) async {
-    final firstConfirm = await showDialog<bool>(
+    final first = await showDialog<bool>(
       context: context,
       builder: (c) => AlertDialog(
+        backgroundColor: AppColors.darkCard,
         title: const Text('회원 탈퇴'),
         content: const Text('정말 탈퇴하시겠습니까?\n모든 기록과 데이터가 삭제되며 복구할 수 없습니다.'),
         actions: [
@@ -154,157 +121,221 @@ class SettingsPage extends ConsumerWidget {
         ],
       ),
     );
-    if (firstConfirm != true || !context.mounted) return;
+    if (first != true || !context.mounted) return;
 
-    final secondConfirm = await showDialog<bool>(
+    final second = await showDialog<bool>(
       context: context,
       builder: (c) => AlertDialog(
+        backgroundColor: AppColors.darkCard,
         title: const Text('마지막 확인'),
         content: const Text('삭제된 데이터는 절대 복구할 수 없습니다.\n정말로 진행하시겠습니까?'),
         actions: [
           TextButton(onPressed: () => Navigator.pop(c, false), child: const Text('취소')),
           TextButton(
             onPressed: () => Navigator.pop(c, true),
-            child: Text('삭제 및 탈퇴', style: TextStyle(color: AppColors.error, fontWeight: FontWeight.w700)),
+            child: Text('삭제 및 탈퇴',
+                style: TextStyle(color: AppColors.error, fontWeight: FontWeight.w700)),
           ),
         ],
       ),
     );
-    if (secondConfirm != true || !context.mounted) return;
+    if (second != true || !context.mounted) return;
 
     try {
       await ref.read(authNotifierProvider.notifier).deleteAccount();
-    } catch (e) {
-      debugPrint('회원 탈퇴 에러: $e');
+    } catch (_) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('탈퇴 처리 중 오류가 발생했습니다'), backgroundColor: AppColors.error, behavior: SnackBarBehavior.floating),
-        );
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: const Text('탈퇴 처리 중 오류가 발생했습니다'),
+          backgroundColor: AppColors.error,
+          behavior: SnackBarBehavior.floating,
+        ));
       }
     }
   }
 }
 
-class _SettingsTile extends StatelessWidget {
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final VoidCallback onTap;
+// ─── 프로필 헤더 ─────────────────────────────────────────────────────────────
 
-  const _SettingsTile({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-    required this.onTap,
-  });
+class _ProfileHeader extends StatelessWidget {
+  final dynamic user;
+  final bool isAdmin;
+
+  const _ProfileHeader({required this.user, required this.isAdmin});
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.only(bottom: 8),
+      width: double.infinity,
       decoration: BoxDecoration(
-        color: AppColors.darkCard,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: AppColors.darkDivider),
-      ),
-      child: ListTile(
-        leading: Container(
-          width: 40,
-          height: 40,
-          decoration: BoxDecoration(
-            color: AppColors.darkDivider,
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: Icon(icon, color: AppColors.textSecondary, size: 20),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppColors.neonOrange.withValues(alpha: 0.2),
+            AppColors.darkBg,
+          ],
         ),
-        title: Text(title, style: TextStyle(color: AppColors.textPrimary, fontWeight: FontWeight.w600, fontSize: 14)),
-        subtitle: Text(subtitle, style: AppTextStyles.labelSmall),
-        trailing: Icon(Icons.chevron_right, color: AppColors.textHint, size: 20),
-        onTap: onTap,
+      ),
+      child: SafeArea(
+        bottom: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 28, 24, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '마이페이지',
+                style: TextStyle(
+                  color: AppColors.textHint,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 1.5,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                user?.nickname ?? '닉네임 없음',
+                style: TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 28,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: -0.5,
+                ),
+              ),
+              if (user?.bowlingStyle != null &&
+                  (user!.bowlingStyle as String).isNotEmpty) ...[
+                const SizedBox(height: 4),
+                Text(
+                  user!.bowlingStyle as String,
+                  style: AppTextStyles.bodyMedium
+                      .copyWith(color: AppColors.textSecondary),
+                ),
+              ],
+              if (isAdmin) ...[
+                const SizedBox(height: 8),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: AppColors.neonOrange.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(5),
+                  ),
+                  child: Text(
+                    'ADMIN',
+                    style: TextStyle(
+                      color: AppColors.neonOrange,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 1.2,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
       ),
     );
   }
 }
 
-class _ColorThemeSelector extends StatelessWidget {
-  final WidgetRef ref;
+// ─── 공통 위젯 ────────────────────────────────────────────────────────────────
 
-  const _ColorThemeSelector({required this.ref});
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
 
   @override
   Widget build(BuildContext context) {
-    final currentTheme = ref.watch(colorThemeProvider);
-
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppColors.darkCard,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: AppColors.darkDivider),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: AppColorTheme.values.map((theme) {
-          final palette = ColorThemes.fromTheme(theme);
-          final isSelected = theme == currentTheme;
-          return GestureDetector(
-            onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
-            child: Column(
-              children: [
-                AnimatedContainer(
-                  duration: const Duration(milliseconds: 200),
-                  width: 48,
-                  height: 48,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    border: Border.all(
-                      color: isSelected ? palette.primary : Colors.transparent,
-                      width: 2.5,
-                    ),
-                  ),
-                  child: Container(
-                    margin: const EdgeInsets.all(3),
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      gradient: LinearGradient(
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                        colors: [palette.bg, palette.primary, palette.secondary],
-                      ),
-                    ),
-                    child: isSelected
-                        ? const Icon(Icons.check, color: Colors.white, size: 18)
-                        : null,
-                  ),
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  _themeName(theme),
-                  style: TextStyle(
-                    color: isSelected ? AppColors.textPrimary : AppColors.textHint,
-                    fontSize: 11,
-                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                  ),
-                ),
-              ],
-            ),
-          );
-        }).toList(),
+    return Text(
+      text,
+      style: TextStyle(
+        color: AppColors.textHint,
+        fontSize: 11,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 1.4,
       ),
     );
   }
+}
 
-  String _themeName(AppColorTheme theme) {
-    switch (theme) {
-      case AppColorTheme.dark:
-        return '다크';
-      case AppColorTheme.cream:
-        return '크림';
-      case AppColorTheme.lavender:
-        return '라벤더';
-      case AppColorTheme.tossBlue:
-        return '블루';
-    }
+/// 항목들을 하나의 카드로 묶어주는 그룹
+class _MenuGroup extends StatelessWidget {
+  final List<_MenuItem> items;
+  const _MenuGroup({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.darkCard,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(children: items),
+    );
+  }
+}
+
+class _MenuItem extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final bool destructive;
+  final bool accent;
+  final bool isLast;
+
+  const _MenuItem({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.destructive = false,
+    this.accent = false,
+    this.isLast = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = destructive
+        ? AppColors.error
+        : accent
+            ? AppColors.neonOrange
+            : AppColors.textPrimary;
+
+    return Column(
+      children: [
+        InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(14),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 15),
+            child: Row(
+              children: [
+                Icon(icon, color: color, size: 20),
+                const SizedBox(width: 14),
+                Text(
+                  label,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const Spacer(),
+                if (!destructive)
+                  Icon(Icons.chevron_right_rounded,
+                      color: AppColors.textHint, size: 18),
+              ],
+            ),
+          ),
+        ),
+        if (!isLast)
+          Divider(
+            height: 1,
+            indent: 50,
+            color: AppColors.darkDivider,
+          ),
+      ],
+    );
   }
 }
 
@@ -313,17 +344,12 @@ class _AppVersionInfo extends StatelessWidget {
   Widget build(BuildContext context) {
     return FutureBuilder<PackageInfo>(
       future: PackageInfo.fromPlatform(),
-      builder: (context, snapshot) {
+      builder: (_, snapshot) {
         final version = snapshot.data?.version ?? '-';
-        final buildNumber = snapshot.data?.buildNumber ?? '-';
-        return Center(
-          child: Text(
-            '핀로그 v$version ($buildNumber)',
-            style: TextStyle(
-              color: AppColors.textHint,
-              fontSize: 12,
-            ),
-          ),
+        final build = snapshot.data?.buildNumber ?? '-';
+        return Text(
+          '핀로그 v$version ($build)',
+          style: TextStyle(color: AppColors.textHint, fontSize: 12),
         );
       },
     );

--- a/lib/features/settings/presentation/pages/theme_selection_page.dart
+++ b/lib/features/settings/presentation/pages/theme_selection_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/color_themes.dart';
+import 'package:bowling_diary/shared/providers/theme_provider.dart';
+
+class ThemeSelectionPage extends ConsumerWidget {
+  const ThemeSelectionPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentTheme = ref.watch(colorThemeProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('테마')),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: AppColorTheme.values.map((theme) {
+          final palette = ColorThemes.fromTheme(theme);
+          final isSelected = theme == currentTheme;
+
+          return GestureDetector(
+            onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              margin: const EdgeInsets.only(bottom: 12),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: AppColors.darkCard,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: isSelected
+                      ? palette.primary
+                      : AppColors.darkDivider,
+                  width: isSelected ? 1.5 : 1,
+                ),
+              ),
+              child: Row(
+                children: [
+                  // 테마 미리보기 원
+                  Container(
+                    width: 44,
+                    height: 44,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient: LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [
+                          palette.bg,
+                          palette.primary,
+                          palette.secondary,
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Text(
+                    _themeName(theme),
+                    style: TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const Spacer(),
+                  if (isSelected)
+                    Icon(Icons.check_rounded,
+                        color: palette.primary, size: 20),
+                ],
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  String _themeName(AppColorTheme theme) {
+    switch (theme) {
+      case AppColorTheme.dark:
+        return '다크';
+      case AppColorTheme.cream:
+        return '크림';
+      case AppColorTheme.lavender:
+        return '라벤더';
+      case AppColorTheme.tossBlue:
+        return '블루';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- 내볼 탭 제거 → 마이페이지 내 리스트 항목으로 이동
- 설정 탭 → 마이페이지로 개편 (텍스트 프로필 헤더, 섹션별 메뉴 그룹)
- 테마 선택 전용 화면 분리 (ThemeSelectionPage)
- 분석 플로우 Navigator 전면 제거 → GoRouter 통합
- 마이페이지 테마 변경 즉시 반영 수정