### PR TITLE
feat: 컬러 테마 3종 라이트·다크 자동 전환, 테마 변경 시 앱 재시작

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,41 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:bowling_diary/app/router/app_router.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_theme.dart';
-import 'package:bowling_diary/shared/providers/theme_provider.dart';
 
-class BowlingDiaryApp extends ConsumerStatefulWidget {
-  const BowlingDiaryApp({super.key});
+/// ProviderScope를 포함한 앱 전체 재시작 위젯
+class AppRestarter extends StatefulWidget {
+  const AppRestarter({super.key});
+
+  static _AppRestarterState of(BuildContext context) =>
+      context.findAncestorStateOfType<_AppRestarterState>()!;
 
   @override
-  ConsumerState<BowlingDiaryApp> createState() => _BowlingDiaryAppState();
+  State<AppRestarter> createState() => _AppRestarterState();
 }
 
-class _BowlingDiaryAppState extends ConsumerState<BowlingDiaryApp>
-    with WidgetsBindingObserver {
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-  }
+class _AppRestarterState extends State<AppRestarter> {
+  Key _key = UniqueKey();
 
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
-
-  @override
-  void didChangePlatformBrightness() {
-    final brightness =
-        WidgetsBinding.instance.platformDispatcher.platformBrightness;
-    ref.read(platformBrightnessProvider.notifier).state = brightness;
-  }
+  /// 호출 시 ProviderScope 포함 전체 재빌드 → 테마 재로드
+  void restart() => setState(() => _key = UniqueKey());
 
   @override
   Widget build(BuildContext context) {
+    return ProviderScope(
+      key: _key,
+      child: const BowlingDiaryApp(),
+    );
+  }
+}
+
+class BowlingDiaryApp extends ConsumerWidget {
+  const BowlingDiaryApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(appRouterProvider);
-    final palette = ref.watch(activePaletteProvider);
+    final palette = AppColors.palette;
     final themeData = AppTheme.fromPalette(palette);
     final themeMode = palette.brightness == Brightness.light
         ? ThemeMode.light

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -2,17 +2,40 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:bowling_diary/app/router/app_router.dart';
 import 'package:bowling_diary/app/theme/app_theme.dart';
-import 'package:bowling_diary/app/theme/color_themes.dart';
 import 'package:bowling_diary/shared/providers/theme_provider.dart';
 
-class BowlingDiaryApp extends ConsumerWidget {
+class BowlingDiaryApp extends ConsumerStatefulWidget {
   const BowlingDiaryApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<BowlingDiaryApp> createState() => _BowlingDiaryAppState();
+}
+
+class _BowlingDiaryAppState extends ConsumerState<BowlingDiaryApp>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangePlatformBrightness() {
+    final brightness =
+        WidgetsBinding.instance.platformDispatcher.platformBrightness;
+    ref.read(platformBrightnessProvider.notifier).state = brightness;
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final router = ref.watch(appRouterProvider);
-    final colorTheme = ref.watch(colorThemeProvider);
-    final palette = ColorThemes.fromTheme(colorTheme);
+    final palette = ref.watch(activePaletteProvider);
     final themeData = AppTheme.fromPalette(palette);
     final themeMode = palette.brightness == Brightness.light
         ? ThemeMode.light
@@ -28,7 +51,7 @@ class BowlingDiaryApp extends ConsumerWidget {
       builder: (context, child) {
         return GestureDetector(
           onTap: () => FocusScope.of(context).unfocus(),
-          child: child,
+          child: child!,
         );
       },
     );

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,13 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bowling_diary/app/router/app_router.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_theme.dart';
+import 'package:bowling_diary/app/theme/color_themes.dart';
 
-/// ProviderScope를 포함한 앱 전체 재시작 위젯
+/// 앱 시작/재시작 전에 팔레트를 동기적으로 세팅
+Future<void> preloadTheme() async {
+  final prefs = await SharedPreferences.getInstance();
+  final idx = prefs.getInt('color_theme_v2');
+  final theme = (idx != null && idx >= 0 && idx < AppColorTheme.values.length)
+      ? AppColorTheme.values[idx]
+      : AppColorTheme.blue;
+  final brightness =
+      WidgetsBinding.instance.platformDispatcher.platformBrightness;
+  AppColors.setPalette(ColorThemes.palette(theme, brightness));
+}
+
 class AppRestarter extends StatefulWidget {
   const AppRestarter({super.key});
 
+  // ignore: library_private_types_in_public_api
   static _AppRestarterState of(BuildContext context) =>
       context.findAncestorStateOfType<_AppRestarterState>()!;
 
@@ -18,8 +32,11 @@ class AppRestarter extends StatefulWidget {
 class _AppRestarterState extends State<AppRestarter> {
   Key _key = UniqueKey();
 
-  /// 호출 시 ProviderScope 포함 전체 재빌드 → 테마 재로드
-  void restart() => setState(() => _key = UniqueKey());
+  /// 팔레트를 먼저 세팅한 뒤 재빌드 — 첫 프레임부터 올바른 색상 적용
+  Future<void> restart() async {
+    await preloadTheme();
+    if (mounted) setState(() => _key = UniqueKey());
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/theme/app_colors.dart
+++ b/lib/app/theme/app_colors.dart
@@ -4,7 +4,7 @@ import 'color_themes.dart';
 class AppColors {
   AppColors._();
 
-  static ColorPalette _palette = ColorThemes.cream;
+  static ColorPalette _palette = ColorThemes.blueLight;
 
   static void setPalette(ColorPalette palette) {
     _palette = palette;

--- a/lib/app/theme/color_themes.dart
+++ b/lib/app/theme/color_themes.dart
@@ -1,11 +1,6 @@
 import 'package:flutter/material.dart';
 
-enum AppColorTheme {
-  dark,
-  cream,
-  lavender,
-  tossBlue,
-}
+enum AppColorTheme { blue, cream, lavender }
 
 class ColorPalette {
   final Color primary;
@@ -46,58 +41,25 @@ class ColorPalette {
 class ColorThemes {
   ColorThemes._();
 
-  static const dark = ColorPalette(
-    primary: Color(0xFFFF6B35),
-    secondary: Color(0xFF00D9A6),
-    primaryGlow: Color(0x33FF6B35),
-    secondaryGlow: Color(0x3300D9A6),
-    brightness: Brightness.dark,
-    bg: Color(0xFF0D0D0D),
-    surface: Color(0xFF1A1A1A),
-    card: Color(0xFF242424),
-    divider: Color(0xFF2E2E2E),
-    textPrimary: Color(0xFFFFFFFF),
-    textSecondary: Color(0xFFAAAAAA),
-    textHint: Color(0xFF666666),
-    error: Color(0xFFFF4757),
-    success: Color(0xFF2ED573),
-  );
-
-  static const cream = ColorPalette(
-    primary: Color(0xFFFF8A65),
-    secondary: Color(0xFF9CDDCE),
-    primaryGlow: Color(0x33FF8A65),
-    secondaryGlow: Color(0x339CDDCE),
+  // ── 블루 ──────────────────────────────────────────────────
+  static const blueLight = ColorPalette(
+    primary: Color(0xFF3182F6),
+    secondary: Color(0xFF00B4D8),
+    primaryGlow: Color(0x333182F6),
+    secondaryGlow: Color(0x3300B4D8),
     brightness: Brightness.light,
-    bg: Color(0xFFFFFBF5),
-    surface: Color(0xFFFFFDF9),
-    card: Color(0xFFFFF9F0),
-    divider: Color(0xFFEDE4D8),
-    textPrimary: Color(0xFF3D2817),
-    textSecondary: Color(0xFF8B7355),
-    textHint: Color(0xFFBBA88A),
-    error: Color(0xFFE8534A),
-    success: Color(0xFF5CB88A),
+    bg: Color(0xFFF2F6FF),
+    surface: Color(0xFFFFFFFF),
+    card: Color(0xFFFFFFFF),
+    divider: Color(0xFFE2EAF5),
+    textPrimary: Color(0xFF191F28),
+    textSecondary: Color(0xFF6B7684),
+    textHint: Color(0xFFB0BAC8),
+    error: Color(0xFFF04452),
+    success: Color(0xFF05C072),
   );
 
-  static const lavender = ColorPalette(
-    primary: Color(0xFF9B72CF),
-    secondary: Color(0xFFE8A0BF),
-    primaryGlow: Color(0x339B72CF),
-    secondaryGlow: Color(0x33E8A0BF),
-    brightness: Brightness.dark,
-    bg: Color(0xFF13111C),
-    surface: Color(0xFF1C1928),
-    card: Color(0xFF252236),
-    divider: Color(0xFF332F48),
-    textPrimary: Color(0xFFF0EBF8),
-    textSecondary: Color(0xFFA49BBF),
-    textHint: Color(0xFF6B6280),
-    error: Color(0xFFFF6B8A),
-    success: Color(0xFF7EE8B7),
-  );
-
-  static const tossBlue = ColorPalette(
+  static const blueDark = ColorPalette(
     primary: Color(0xFF3182F6),
     secondary: Color(0xFF4DD0E1),
     primaryGlow: Color(0x333182F6),
@@ -114,16 +76,94 @@ class ColorThemes {
     success: Color(0xFF69DB7C),
   );
 
-  static ColorPalette fromTheme(AppColorTheme theme) {
+  // ── 크림 ──────────────────────────────────────────────────
+  static const creamLight = ColorPalette(
+    primary: Color(0xFFFF8A65),
+    secondary: Color(0xFF9CDDCE),
+    primaryGlow: Color(0x33FF8A65),
+    secondaryGlow: Color(0x339CDDCE),
+    brightness: Brightness.light,
+    bg: Color(0xFFFFFBF5),
+    surface: Color(0xFFFFFFFF),
+    card: Color(0xFFFFF9F0),
+    divider: Color(0xFFEDE4D8),
+    textPrimary: Color(0xFF3D2817),
+    textSecondary: Color(0xFF8B7355),
+    textHint: Color(0xFFBBA88A),
+    error: Color(0xFFE8534A),
+    success: Color(0xFF5CB88A),
+  );
+
+  static const creamDark = ColorPalette(
+    primary: Color(0xFFFF8A65),
+    secondary: Color(0xFF9CDDCE),
+    primaryGlow: Color(0x33FF8A65),
+    secondaryGlow: Color(0x339CDDCE),
+    brightness: Brightness.dark,
+    bg: Color(0xFF1A1208),
+    surface: Color(0xFF231A10),
+    card: Color(0xFF2C2215),
+    divider: Color(0xFF3D3020),
+    textPrimary: Color(0xFFF5EFE6),
+    textSecondary: Color(0xFFC4A882),
+    textHint: Color(0xFF8A7060),
+    error: Color(0xFFFF6B5B),
+    success: Color(0xFF6DD9A0),
+  );
+
+  // ── 라벤더 ────────────────────────────────────────────────
+  static const lavenderLight = ColorPalette(
+    primary: Color(0xFF7B61FF),
+    secondary: Color(0xFFE8A0BF),
+    primaryGlow: Color(0x337B61FF),
+    secondaryGlow: Color(0x33E8A0BF),
+    brightness: Brightness.light,
+    bg: Color(0xFFF8F5FF),
+    surface: Color(0xFFFFFFFF),
+    card: Color(0xFFFFFFFF),
+    divider: Color(0xFFE8E0F5),
+    textPrimary: Color(0xFF1A1625),
+    textSecondary: Color(0xFF6B5F80),
+    textHint: Color(0xFFA899C0),
+    error: Color(0xFFE84057),
+    success: Color(0xFF2DB87A),
+  );
+
+  static const lavenderDark = ColorPalette(
+    primary: Color(0xFF9B72CF),
+    secondary: Color(0xFFE8A0BF),
+    primaryGlow: Color(0x339B72CF),
+    secondaryGlow: Color(0x33E8A0BF),
+    brightness: Brightness.dark,
+    bg: Color(0xFF13111C),
+    surface: Color(0xFF1C1928),
+    card: Color(0xFF252236),
+    divider: Color(0xFF332F48),
+    textPrimary: Color(0xFFF0EBF8),
+    textSecondary: Color(0xFFA49BBF),
+    textHint: Color(0xFF6B6280),
+    error: Color(0xFFFF6B8A),
+    success: Color(0xFF7EE8B7),
+  );
+
+  /// 테마 + 디바이스 밝기에 맞는 팔레트 반환
+  static ColorPalette palette(AppColorTheme theme, Brightness brightness) {
+    final isDark = brightness == Brightness.dark;
     switch (theme) {
-      case AppColorTheme.dark:
-        return dark;
+      case AppColorTheme.blue:
+        return isDark ? blueDark : blueLight;
       case AppColorTheme.cream:
-        return cream;
+        return isDark ? creamDark : creamLight;
       case AppColorTheme.lavender:
-        return lavender;
-      case AppColorTheme.tossBlue:
-        return tossBlue;
+        return isDark ? lavenderDark : lavenderLight;
     }
   }
+
+  /// ThemeSelectionPage 미리보기용 — 라이트 팔레트 반환
+  static ColorPalette previewLight(AppColorTheme theme) =>
+      palette(theme, Brightness.light);
+
+  /// ThemeSelectionPage 미리보기용 — 다크 팔레트 반환
+  static ColorPalette previewDark(AppColorTheme theme) =>
+      palette(theme, Brightness.dark);
 }

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -66,9 +66,11 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   Future<void> _init() async {
+    if (!mounted) return;
     state = AuthStateLoading();
     final session = _supabase.auth.currentSession;
     if (session == null) {
+      if (!mounted) return;
       state = AuthStateUnauthenticated();
       return;
     }
@@ -83,6 +85,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
           .eq('id', userId)
           .maybeSingle();
 
+      if (!mounted) return;
       if (data == null) {
         state = AuthStateNeedsProfile(userId);
       } else {
@@ -94,6 +97,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
         }
       }
     } catch (e) {
+      if (!mounted) return;
       state = AuthStateNeedsProfile(userId);
     }
   }
@@ -271,9 +275,11 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   void _handleAuthStateChange(AuthChangeEvent event, Session? session) {
+    if (!mounted) return;
     if (event == AuthChangeEvent.signedIn && session != null) {
       _loadUserProfile(session.user.id);
     } else if (event == AuthChangeEvent.signedOut) {
+      if (!mounted) return;
       state = AuthStateUnauthenticated();
     }
   }

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -37,9 +37,7 @@ class AuthStateError extends AuthState {
 
 final authNotifierProvider =
     StateNotifierProvider<AuthNotifier, AuthState>((ref) {
-  final notifier = AuthNotifier();
-  ref.onDispose(() => notifier.dispose());
-  return notifier;
+  return AuthNotifier();
 });
 
 final currentUserProvider = Provider<UserEntity?>((ref) {

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -13,7 +13,6 @@ class SettingsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.watch(colorThemeProvider);
     final user = ref.watch(currentUserProvider);
     final isAdmin = user?.isAdmin ?? false;
 

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -245,7 +245,7 @@ class _ColorThemeSelector extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: AppColorTheme.values.map((theme) {
-          final palette = ColorThemes.fromTheme(theme);
+          final palette = ColorThemes.previewLight(theme);
           final isSelected = theme == currentTheme;
           return GestureDetector(
             onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
@@ -296,14 +296,12 @@ class _ColorThemeSelector extends StatelessWidget {
 
   String _themeName(AppColorTheme theme) {
     switch (theme) {
-      case AppColorTheme.dark:
-        return '다크';
+      case AppColorTheme.blue:
+        return '블루';
       case AppColorTheme.cream:
         return '크림';
       case AppColorTheme.lavender:
         return '라벤더';
-      case AppColorTheme.tossBlue:
-        return '블루';
     }
   }
 }

--- a/lib/features/settings/presentation/pages/theme_selection_page.dart
+++ b/lib/features/settings/presentation/pages/theme_selection_page.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:bowling_diary/app/theme/app_colors.dart';
+import 'package:bowling_diary/app/theme/app_text_styles.dart';
+import 'package:bowling_diary/app/theme/color_themes.dart';
+import 'package:bowling_diary/shared/providers/theme_provider.dart';
+
+class ThemeSelectionPage extends ConsumerWidget {
+  const ThemeSelectionPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentTheme = ref.watch(colorThemeProvider);
+    final currentBrightness = ref.watch(platformBrightnessProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('테마')),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          Text(
+            '디바이스 다크모드에 따라 자동으로 색상이 변경됩니다.',
+            style: AppTextStyles.bodySmall
+                .copyWith(color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: 20),
+          ...AppColorTheme.values.map((theme) {
+            final isSelected = theme == currentTheme;
+            final lightPalette = ColorThemes.previewLight(theme);
+            final darkPalette = ColorThemes.previewDark(theme);
+            final activePalette = ColorThemes.palette(theme, currentBrightness);
+
+            return GestureDetector(
+              onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                margin: const EdgeInsets.only(bottom: 12),
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: AppColors.darkCard,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                    color: isSelected
+                        ? activePalette.primary
+                        : AppColors.darkDivider,
+                    width: isSelected ? 1.5 : 1,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    // 라이트/다크 미리보기 원 2개
+                    Row(
+                      children: [
+                        _PreviewCircle(palette: lightPalette, label: '라이트'),
+                        const SizedBox(width: 8),
+                        _PreviewCircle(palette: darkPalette, label: '다크'),
+                      ],
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            _themeName(theme),
+                            style: TextStyle(
+                              color: AppColors.textPrimary,
+                              fontSize: 15,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            _themeDesc(theme),
+                            style: AppTextStyles.bodySmall.copyWith(
+                              color: AppColors.textHint,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (isSelected)
+                      Icon(Icons.check_rounded,
+                          color: activePalette.primary, size: 20),
+                  ],
+                ),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  String _themeName(AppColorTheme theme) {
+    switch (theme) {
+      case AppColorTheme.blue:
+        return '블루';
+      case AppColorTheme.cream:
+        return '크림';
+      case AppColorTheme.lavender:
+        return '라벤더';
+    }
+  }
+
+  String _themeDesc(AppColorTheme theme) {
+    switch (theme) {
+      case AppColorTheme.blue:
+        return '깔끔하고 신뢰감 있는 블루 계열';
+      case AppColorTheme.cream:
+        return '따뜻하고 아늑한 크림 계열';
+      case AppColorTheme.lavender:
+        return '부드럽고 감각적인 라벤더 계열';
+    }
+  }
+}
+
+class _PreviewCircle extends StatelessWidget {
+  final ColorPalette palette;
+  final String label;
+
+  const _PreviewCircle({required this.palette, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [palette.bg, palette.card, palette.primary],
+            ),
+            border: Border.all(
+              color: Colors.black.withValues(alpha: 0.1),
+              width: 0.5,
+            ),
+          ),
+          child: Center(
+            child: Container(
+              width: 14,
+              height: 14,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: palette.primary,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 9,
+            color: AppColors.textHint,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/presentation/pages/theme_selection_page.dart
+++ b/lib/features/settings/presentation/pages/theme_selection_page.dart
@@ -35,7 +35,7 @@ class ThemeSelectionPage extends ConsumerWidget {
             return GestureDetector(
               onTap: () async {
                 await ref.read(colorThemeProvider.notifier).setTheme(theme);
-                if (context.mounted) AppRestarter.of(context).restart();
+                if (context.mounted) await AppRestarter.of(context).restart();
               },
               child: AnimatedContainer(
                 duration: const Duration(milliseconds: 200),

--- a/lib/features/settings/presentation/pages/theme_selection_page.dart
+++ b/lib/features/settings/presentation/pages/theme_selection_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:bowling_diary/app/app.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/app_text_styles.dart';
 import 'package:bowling_diary/app/theme/color_themes.dart';
@@ -11,7 +12,8 @@ class ThemeSelectionPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currentTheme = ref.watch(colorThemeProvider);
-    final currentBrightness = ref.watch(platformBrightnessProvider);
+    final currentBrightness =
+        WidgetsBinding.instance.platformDispatcher.platformBrightness;
 
     return Scaffold(
       appBar: AppBar(title: const Text('테마')),
@@ -31,7 +33,10 @@ class ThemeSelectionPage extends ConsumerWidget {
             final activePalette = ColorThemes.palette(theme, currentBrightness);
 
             return GestureDetector(
-              onTap: () => ref.read(colorThemeProvider.notifier).setTheme(theme),
+              onTap: () async {
+                await ref.read(colorThemeProvider.notifier).setTheme(theme);
+                if (context.mounted) AppRestarter.of(context).restart();
+              },
               child: AnimatedContainer(
                 duration: const Duration(milliseconds: 200),
                 margin: const EdgeInsets.only(bottom: 12),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:bowling_diary/app/app.dart';
+import 'package:bowling_diary/app/app.dart' show AppRestarter, preloadTheme;
 import 'package:bowling_diary/core/constants/supabase_constants.dart';
 
 void main() async {
@@ -17,6 +16,7 @@ void main() async {
     anonKey: SupabaseConstants.anonKey,
   );
 
+  await preloadTheme(); // 첫 프레임 전에 팔레트 세팅
   FlutterNativeSplash.remove();
 
   runApp(const AppRestarter());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,9 +19,5 @@ void main() async {
 
   FlutterNativeSplash.remove();
 
-  runApp(
-    const ProviderScope(
-      child: BowlingDiaryApp(),
-    ),
-  );
+  runApp(const AppRestarter());
 }

--- a/lib/shared/providers/theme_provider.dart
+++ b/lib/shared/providers/theme_provider.dart
@@ -4,38 +4,43 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/color_themes.dart';
 
-final colorThemeProvider = StateNotifierProvider<ColorThemeNotifier, AppColorTheme>((ref) {
+/// 사용자가 선택한 테마 스타일 (3종)
+final colorThemeProvider =
+    StateNotifierProvider<ColorThemeNotifier, AppColorTheme>((ref) {
   return ColorThemeNotifier();
 });
 
-final themeProvider = Provider<ThemeMode>((ref) {
-  final colorTheme = ref.watch(colorThemeProvider);
-  final palette = ColorThemes.fromTheme(colorTheme);
-  return palette.brightness == Brightness.light ? ThemeMode.light : ThemeMode.dark;
+/// 디바이스 밝기 — app.dart의 WidgetsBindingObserver가 업데이트
+final platformBrightnessProvider =
+    StateProvider<Brightness>((ref) {
+  return WidgetsBinding.instance.platformDispatcher.platformBrightness;
+});
+
+/// 현재 활성 팔레트 (테마 + 밝기 조합)
+final activePaletteProvider = Provider<ColorPalette>((ref) {
+  final theme = ref.watch(colorThemeProvider);
+  final brightness = ref.watch(platformBrightnessProvider);
+  final palette = ColorThemes.palette(theme, brightness);
+  AppColors.setPalette(palette);
+  return palette;
 });
 
 class ColorThemeNotifier extends StateNotifier<AppColorTheme> {
-  ColorThemeNotifier() : super(AppColorTheme.cream) {
+  ColorThemeNotifier() : super(AppColorTheme.blue) {
     _load();
   }
 
-  static const _key = 'color_theme';
+  static const _key = 'color_theme_v2';
 
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
     final idx = prefs.getInt(_key);
     if (idx != null && idx >= 0 && idx < AppColorTheme.values.length) {
-      final theme = AppColorTheme.values[idx];
-      AppColors.setPalette(ColorThemes.fromTheme(theme));
-      state = theme;
-    } else {
-      AppColors.setPalette(ColorThemes.cream);
-      state = AppColorTheme.cream;
+      state = AppColorTheme.values[idx];
     }
   }
 
   Future<void> setTheme(AppColorTheme theme) async {
-    AppColors.setPalette(ColorThemes.fromTheme(theme));
     state = theme;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_key, theme.index);

--- a/lib/shared/providers/theme_provider.dart
+++ b/lib/shared/providers/theme_provider.dart
@@ -4,25 +4,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
 import 'package:bowling_diary/app/theme/color_themes.dart';
 
-/// 사용자가 선택한 테마 스타일 (3종)
 final colorThemeProvider =
     StateNotifierProvider<ColorThemeNotifier, AppColorTheme>((ref) {
   return ColorThemeNotifier();
-});
-
-/// 디바이스 밝기 — app.dart의 WidgetsBindingObserver가 업데이트
-final platformBrightnessProvider =
-    StateProvider<Brightness>((ref) {
-  return WidgetsBinding.instance.platformDispatcher.platformBrightness;
-});
-
-/// 현재 활성 팔레트 (테마 + 밝기 조합)
-final activePaletteProvider = Provider<ColorPalette>((ref) {
-  final theme = ref.watch(colorThemeProvider);
-  final brightness = ref.watch(platformBrightnessProvider);
-  final palette = ColorThemes.palette(theme, brightness);
-  AppColors.setPalette(palette);
-  return palette;
 });
 
 class ColorThemeNotifier extends StateNotifier<AppColorTheme> {
@@ -35,11 +19,18 @@ class ColorThemeNotifier extends StateNotifier<AppColorTheme> {
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
     final idx = prefs.getInt(_key);
-    if (idx != null && idx >= 0 && idx < AppColorTheme.values.length) {
-      state = AppColorTheme.values[idx];
-    }
+    final theme = (idx != null && idx >= 0 && idx < AppColorTheme.values.length)
+        ? AppColorTheme.values[idx]
+        : AppColorTheme.blue;
+
+    // 앱 시작 시 디바이스 밝기 한 번 감지
+    final brightness =
+        WidgetsBinding.instance.platformDispatcher.platformBrightness;
+    AppColors.setPalette(ColorThemes.palette(theme, brightness));
+    state = theme;
   }
 
+  /// 테마 저장 후 앱을 재시작해야 실제로 적용됨
   Future<void> setTheme(AppColorTheme theme) async {
     state = theme;
     final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary
- 테마 3종 (블루/크림/라벤더) 각 라이트·다크 변형 추가
- 디바이스 다크모드에 따라 앱 시작 시 자동 팔레트 적용
- 테마 변경 시 `AppRestarter`로 앱 전체 재시작 → 코드 단순화
- `preloadTheme()`으로 첫 프레임 전에 팔레트 세팅 (두 번 눌러야 적용되던 버그 수정)
- `AuthNotifier` 이중 dispose 제거, mounted 체크 추가