### PR TITLE
hotfix: Gemini API 키 누락 및 분석 탭 임시 비활성화 (v1.2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,116 @@
-# bowling_diary
+# 볼링다이어리 🎳
 
-A new Flutter project.
+볼링 점수를 스마트하게 기록하고 투구를 분석하는 iOS 앱
 
-## Getting Started
+---
 
-This project is a starting point for a Flutter application.
+## 주요 기능
 
-A few resources to get you started if this is your first Flutter project:
+### 스코어 기록
+스코어보드를 촬영하면 OCR이 자동으로 점수를 인식해 기록합니다.
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+<!-- TODO: 스크린샷 추가 -->
+<!-- ![스코어 기록](docs/screenshots/score_record.png) -->
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+### 투구 분석 `BETA`
+갤러리에서 투구 영상을 선택하면 구속과 RPM을 자동 분석합니다.
+
+- **구속 (km/h)**: Gemini Vision이 레인 랜드마크(파울라인, 화살표, 헤드핀)를 식별해 계산
+- **RPM**: 볼 표면 텍스처 패턴 변화 추적
+
+> 카메라 앵글과 조명 조건에 따라 정확도가 달라질 수 있습니다.
+
+<!-- TODO: 스크린샷 추가 -->
+<!-- ![투구 분석](docs/screenshots/analysis.png) -->
+
+### 통계 & 히스토리
+게임 기록을 바탕으로 개인 볼링 데이터를 관리하고 통계를 확인합니다.
+
+<!-- TODO: 스크린샷 추가 -->
+<!-- ![통계](docs/screenshots/stats.png) -->
+
+### 볼 관리
+보유 중인 볼링공을 등록하고 카탈로그에서 정보를 검색할 수 있습니다.
+
+<!-- TODO: 스크린샷 추가 -->
+<!-- ![볼 관리](docs/screenshots/balls.png) -->
+
+---
+
+## 기술 스택
+
+| 분류 | 기술 |
+|------|------|
+| Framework | Flutter (iOS) |
+| 상태 관리 | Riverpod |
+| 라우팅 | GoRouter |
+| 백엔드 | Supabase |
+| OCR | Google ML Kit (Korean) |
+| 영상 분석 | YOLOv8n TFLite + Gemini 2.5 Flash Vision |
+| 영상 처리 | FFmpeg Kit |
+
+---
+
+## 아키텍처
+
+Clean Architecture 기반 — `domain / data / presentation` 레이어 분리
+
+```
+lib/
+├── app/           # 라우터, 테마
+├── core/          # 공통 유틸, 상수
+└── features/
+    ├── record/    # 스코어 기록 (OCR)
+    ├── analysis/  # 투구 분석
+    ├── balls/     # 볼 관리
+    └── auth/      # 인증
+```
+
+---
+
+## 설치 및 실행
+
+### 요구사항
+- Flutter 3.x 이상
+- Xcode (iOS 빌드)
+- Supabase 프로젝트
+- Gemini API 키
+
+### 환경 변수 설정
+
+```bash
+flutter run \
+  --dart-define=SUPABASE_URL=your_url \
+  --dart-define=SUPABASE_ANON_KEY=your_key \
+  --dart-define=GEMINI_API_KEY=your_key
+```
+
+### 실행
+
+```bash
+flutter pub get
+flutter run
+```
+
+---
+
+## 볼링 도메인
+
+### 스코어보드 구조
+- 플레이어당 2행: **핀 카운트 행** + **누적 점수 행**
+- 프레임 1~9: 투구 2개 / 프레임 10: 투구 최대 3개
+
+### 점수 표기
+
+| 표기 | 의미 |
+|------|------|
+| 볼/깃발 아이콘 | 스트라이크 |
+| `/` | 스페어 |
+| `-` | 거터/미스 |
+| 숫자 | 쓰러뜨린 핀 수 |
+
+---
+
+## 라이선스
+
+MIT

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -14,7 +14,7 @@ import 'package:bowling_diary/features/balls/presentation/pages/ball_form_page.d
 import 'package:bowling_diary/features/balls/presentation/pages/balls_page.dart';
 import 'package:bowling_diary/features/settings/presentation/pages/settings_page.dart';
 import 'package:bowling_diary/features/admin/presentation/pages/catalog_manage_page.dart';
-import 'package:bowling_diary/features/analysis/presentation/pages/analysis_tab_page.dart';
+// import 'package:bowling_diary/features/analysis/presentation/pages/analysis_tab_page.dart'; // 임시 비활성화
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_guide_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_camera_page.dart';
 import 'package:bowling_diary/features/analysis/presentation/pages/analysis_result_page.dart';
@@ -139,14 +139,15 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               ),
             ],
           ),
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/analysis',
-                builder: (context, state) => const AnalysisTabPage(),
-              ),
-            ],
-          ),
+          // 분석 탭 임시 비활성화 (앱스토어 이슈)
+          // StatefulShellBranch(
+          //   routes: [
+          //     GoRoute(
+          //       path: '/analysis',
+          //       builder: (context, state) => const AnalysisTabPage(),
+          //     ),
+          //   ],
+          // ),
           StatefulShellBranch(
             routes: [
               GoRoute(
@@ -222,20 +223,21 @@ class _CustomNavBar extends StatelessWidget {
                 isActive: currentIndex == 1,
                 onTap: () => onTap(1),
               ),
-              _NavItem(
-                icon: PhosphorIconsRegular.videoCamera,
-                activeIcon: PhosphorIconsFill.videoCamera,
-                label: '분석',
-                isActive: currentIndex == 2,
-                onTap: () => onTap(2),
-                showBeta: true,
-              ),
+              // 분석 탭 임시 비활성화 (앱스토어 이슈)
+              // _NavItem(
+              //   icon: PhosphorIconsRegular.videoCamera,
+              //   activeIcon: PhosphorIconsFill.videoCamera,
+              //   label: '분석',
+              //   isActive: currentIndex == 2,
+              //   onTap: () => onTap(2),
+              //   showBeta: true,
+              // ),
               _NavItem(
                 icon: PhosphorIconsRegular.user,
                 activeIcon: PhosphorIconsFill.user,
                 label: '마이페이지',
-                isActive: currentIndex == 3,
-                onTap: () => onTap(3),
+                isActive: currentIndex == 2,
+                onTap: () => onTap(2),
               ),
             ],
           ),

--- a/lib/features/analysis/data/services/gemini_analysis_service.dart
+++ b/lib/features/analysis/data/services/gemini_analysis_service.dart
@@ -11,17 +11,6 @@ List<String> _encodeFrames(List<img.Image> frames) {
   return frames.map((f) => base64Encode(img.encodeJpg(f, quality: 65))).toList();
 }
 
-class GeminiAnalysisResult {
-  final AnalysisData data;
-  final Map<String, int?>? landmarkFrames;
-  final List<img.Image>? sampledFrames;
-
-  const GeminiAnalysisResult({
-    required this.data,
-    this.landmarkFrames,
-    this.sampledFrames,
-  });
-}
 
 class GeminiAnalysisService {
   static const _baseUrl = 'https://generativelanguage.googleapis.com';
@@ -245,15 +234,15 @@ JSON만 반환하세요.
   }
 
   /// 속도(전체 프레임 랜드마크) + RPM(크롭 볼 이미지) 통합 단일 API 호출
-  Future<GeminiAnalysisResult> analyzeUnified({
+  Future<AnalysisData> analyzeUnified({
     required List<img.Image> frames,
     required List<BallDetection?> ballDetections,
     required int releaseFrame,
     required int sampleFps,
   }) async {
     final apiKey = AppConfig.geminiApiKey;
-    if (apiKey.isEmpty) return GeminiAnalysisResult(data: AnalysisData(framesAnalyzed: frames.length, fpsUsed: sampleFps));
-    if (frames.isEmpty) return GeminiAnalysisResult(data: AnalysisData(framesAnalyzed: 0, fpsUsed: sampleFps));
+    if (apiKey.isEmpty) return AnalysisData(framesAnalyzed: frames.length, fpsUsed: sampleFps);
+    if (frames.isEmpty) return AnalysisData(framesAnalyzed: 0, fpsUsed: sampleFps);
 
     // 30→40장으로 증가: 핀 충돌 구간(후반부) 포함 확률 향상
     const maxFullFrames = 40;
@@ -317,7 +306,6 @@ JSON만 반환하세요.
     return _parseUnifiedResponse(
       res.body, sampleFps, frames.length,
       fullIntervalSec, cropFrames.length, cropIntervalSec,
-      sampledFrames: kDebugMode ? fullFrames : null,
     );
   }
 
@@ -380,15 +368,14 @@ JSON만 반환:
   "rotation_count": null
 }''';
 
-  GeminiAnalysisResult _parseUnifiedResponse(
+  AnalysisData _parseUnifiedResponse(
     String body,
     int sampleFps,
     int totalFrames,
     double fullIntervalSec,
     int cropFrameCount,
-    double cropIntervalSec, {
-    List<img.Image>? sampledFrames,
-  }) {
+    double cropIntervalSec,
+  ) {
     try {
       final json = jsonDecode(body);
       final text = json['candidates'][0]['content']['parts'][0]['text'] as String;
@@ -443,16 +430,10 @@ JSON만 반환:
       }
 
       debugPrint('[GeminiAnalysis] 결과: ${speedKmh?.toStringAsFixed(1) ?? '측정불가'}km/h, RPM=$rpm');
-      return GeminiAnalysisResult(
-        data: AnalysisData(speedKmh: speedKmh, rpmEstimated: rpm, framesAnalyzed: totalFrames, fpsUsed: sampleFps),
-        landmarkFrames: kDebugMode ? {'foul_line': foulLineFrame, 'arrows': arrowsFrame, 'headpin': headpinFrame} : null,
-        sampledFrames: sampledFrames,
-      );
+      return AnalysisData(speedKmh: speedKmh, rpmEstimated: rpm, framesAnalyzed: totalFrames, fpsUsed: sampleFps);
     } catch (e) {
       debugPrint('[GeminiAnalysis] 파싱 오류: $e\n$body');
-      return GeminiAnalysisResult(
-        data: AnalysisData(framesAnalyzed: totalFrames, fpsUsed: sampleFps),
-      );
+      return AnalysisData(framesAnalyzed: totalFrames, fpsUsed: sampleFps);
     }
   }
 }

--- a/lib/features/analysis/data/services/gemini_analysis_service.dart
+++ b/lib/features/analysis/data/services/gemini_analysis_service.dart
@@ -11,6 +11,18 @@ List<String> _encodeFrames(List<img.Image> frames) {
   return frames.map((f) => base64Encode(img.encodeJpg(f, quality: 65))).toList();
 }
 
+class GeminiAnalysisResult {
+  final AnalysisData data;
+  final Map<String, int?>? landmarkFrames;
+  final List<img.Image>? sampledFrames;
+
+  const GeminiAnalysisResult({
+    required this.data,
+    this.landmarkFrames,
+    this.sampledFrames,
+  });
+}
+
 class GeminiAnalysisService {
   static const _baseUrl = 'https://generativelanguage.googleapis.com';
   static const _sampleFps = 10.0;
@@ -233,15 +245,15 @@ JSON만 반환하세요.
   }
 
   /// 속도(전체 프레임 랜드마크) + RPM(크롭 볼 이미지) 통합 단일 API 호출
-  Future<AnalysisData> analyzeUnified({
+  Future<GeminiAnalysisResult> analyzeUnified({
     required List<img.Image> frames,
     required List<BallDetection?> ballDetections,
     required int releaseFrame,
     required int sampleFps,
   }) async {
     final apiKey = AppConfig.geminiApiKey;
-    if (apiKey.isEmpty) return AnalysisData(framesAnalyzed: frames.length, fpsUsed: sampleFps);
-    if (frames.isEmpty) return AnalysisData(framesAnalyzed: 0, fpsUsed: sampleFps);
+    if (apiKey.isEmpty) return GeminiAnalysisResult(data: AnalysisData(framesAnalyzed: frames.length, fpsUsed: sampleFps));
+    if (frames.isEmpty) return GeminiAnalysisResult(data: AnalysisData(framesAnalyzed: 0, fpsUsed: sampleFps));
 
     // 30→40장으로 증가: 핀 충돌 구간(후반부) 포함 확률 향상
     const maxFullFrames = 40;
@@ -305,6 +317,7 @@ JSON만 반환하세요.
     return _parseUnifiedResponse(
       res.body, sampleFps, frames.length,
       fullIntervalSec, cropFrames.length, cropIntervalSec,
+      sampledFrames: kDebugMode ? fullFrames : null,
     );
   }
 
@@ -367,14 +380,15 @@ JSON만 반환:
   "rotation_count": null
 }''';
 
-  AnalysisData _parseUnifiedResponse(
+  GeminiAnalysisResult _parseUnifiedResponse(
     String body,
     int sampleFps,
     int totalFrames,
     double fullIntervalSec,
     int cropFrameCount,
-    double cropIntervalSec,
-  ) {
+    double cropIntervalSec, {
+    List<img.Image>? sampledFrames,
+  }) {
     try {
       final json = jsonDecode(body);
       final text = json['candidates'][0]['content']['parts'][0]['text'] as String;
@@ -391,10 +405,11 @@ JSON만 반환:
       int? startFrame, endFrame;
       double? distance;
 
-      if (foulLineFrame != null && headpinFrame != null && headpinFrame > foulLineFrame) {
-        startFrame = foulLineFrame; endFrame = headpinFrame; distance = 18.29;
-      } else if (foulLineFrame != null && arrowsFrame != null && arrowsFrame > foulLineFrame) {
+      // 우선순위: 파울라인↔화살표(4.57m, 안정적) > 파울라인↔헤드핀(18.29m) > 화살표↔헤드핀(13.72m)
+      if (foulLineFrame != null && arrowsFrame != null && arrowsFrame > foulLineFrame) {
         startFrame = foulLineFrame; endFrame = arrowsFrame; distance = 4.57;
+      } else if (foulLineFrame != null && headpinFrame != null && headpinFrame > foulLineFrame) {
+        startFrame = foulLineFrame; endFrame = headpinFrame; distance = 18.29;
       } else if (arrowsFrame != null && headpinFrame != null && headpinFrame > arrowsFrame) {
         startFrame = arrowsFrame; endFrame = headpinFrame; distance = 13.72;
       }
@@ -428,10 +443,16 @@ JSON만 반환:
       }
 
       debugPrint('[GeminiAnalysis] 결과: ${speedKmh?.toStringAsFixed(1) ?? '측정불가'}km/h, RPM=$rpm');
-      return AnalysisData(speedKmh: speedKmh, rpmEstimated: rpm, framesAnalyzed: totalFrames, fpsUsed: sampleFps);
+      return GeminiAnalysisResult(
+        data: AnalysisData(speedKmh: speedKmh, rpmEstimated: rpm, framesAnalyzed: totalFrames, fpsUsed: sampleFps),
+        landmarkFrames: kDebugMode ? {'foul_line': foulLineFrame, 'arrows': arrowsFrame, 'headpin': headpinFrame} : null,
+        sampledFrames: sampledFrames,
+      );
     } catch (e) {
       debugPrint('[GeminiAnalysis] 파싱 오류: $e\n$body');
-      return AnalysisData(framesAnalyzed: totalFrames, fpsUsed: sampleFps);
+      return GeminiAnalysisResult(
+        data: AnalysisData(framesAnalyzed: totalFrames, fpsUsed: sampleFps),
+      );
     }
   }
 }

--- a/lib/features/analysis/data/services/pin_impact_detector_service.dart
+++ b/lib/features/analysis/data/services/pin_impact_detector_service.dart
@@ -11,6 +11,7 @@ class PinImpactDetectorService {
 
   int? findImpactFrame(List<img.Image> frames, int releaseFrame) {
     if (frames.length < 2) return null;
+    if (releaseFrame >= frames.length) return null;
 
     final searchStart = releaseFrame + _minTravelFrames;
     if (searchStart >= frames.length) return null;

--- a/lib/features/analysis/data/services/pin_impact_detector_service.dart
+++ b/lib/features/analysis/data/services/pin_impact_detector_service.dart
@@ -5,25 +5,33 @@ class PinImpactDetectorService {
   static const _pinZoneRatio = 0.20;
   static const _changeThreshold = 0.15;
   static const double _pixelDiffThreshold = 30.0;
+  // 릴리즈 직후 볼 스윙 이벤트를 오탐하지 않도록 최소 탐색 시작 프레임
+  // 50 km/h 기준 18.29m 이동 = 1.3s = 39프레임 → 여유분 포함 20프레임
+  static const _minTravelFrames = 20;
 
   int? findImpactFrame(List<img.Image> frames, int releaseFrame) {
     if (frames.length < 2) return null;
 
-    // releaseFrame이 기준 프레임 — 다음 프레임부터 비교 시작
-    img.Image? prevZone;
+    final searchStart = releaseFrame + _minTravelFrames;
+    if (searchStart >= frames.length) return null;
 
-    for (int i = releaseFrame; i < frames.length; i++) {
+    // 릴리즈 프레임을 기준으로 prevZone 초기화 (릴리즈 이후 변화를 무시하기 위해)
+    final seedFrame = frames[releaseFrame];
+    final seedH = (seedFrame.height * _pinZoneRatio).round().clamp(1, seedFrame.height);
+    img.Image? prevZone = img.grayscale(
+      img.copyCrop(seedFrame, x: 0, y: 0, width: seedFrame.width, height: seedH),
+    );
+
+    for (int i = searchStart; i < frames.length; i++) {
       final frame = frames[i];
       final zoneH = (frame.height * _pinZoneRatio).round().clamp(1, frame.height);
       final zone = img.copyCrop(frame, x: 0, y: 0, width: frame.width, height: zoneH);
       final grayZone = img.grayscale(zone);
 
-      if (prevZone != null) {
-        final ratio = _changeRatio(prevZone, grayZone);
-        if (ratio >= _changeThreshold) {
-          debugPrint('[PinImpact] 핀 충돌 프레임: $i (변화율: ${(ratio * 100).toStringAsFixed(1)}%)');
-          return i;
-        }
+      final ratio = _changeRatio(prevZone!, grayZone);
+      if (ratio >= _changeThreshold) {
+        debugPrint('[PinImpact] 핀 충돌 프레임: $i (변화율: ${(ratio * 100).toStringAsFixed(1)}%)');
+        return i;
       }
       prevZone = grayZone;
     }

--- a/lib/features/analysis/data/services/pin_impact_detector_service.dart
+++ b/lib/features/analysis/data/services/pin_impact_detector_service.dart
@@ -19,7 +19,7 @@ class PinImpactDetectorService {
     // 릴리즈 프레임을 기준으로 prevZone 초기화 (릴리즈 이후 변화를 무시하기 위해)
     final seedFrame = frames[releaseFrame];
     final seedH = (seedFrame.height * _pinZoneRatio).round().clamp(1, seedFrame.height);
-    img.Image? prevZone = img.grayscale(
+    img.Image prevZone = img.grayscale(
       img.copyCrop(seedFrame, x: 0, y: 0, width: seedFrame.width, height: seedH),
     );
 
@@ -29,7 +29,7 @@ class PinImpactDetectorService {
       final zone = img.copyCrop(frame, x: 0, y: 0, width: frame.width, height: zoneH);
       final grayZone = img.grayscale(zone);
 
-      final ratio = _changeRatio(prevZone!, grayZone);
+      final ratio = _changeRatio(prevZone, grayZone);
       if (ratio >= _changeThreshold) {
         debugPrint('[PinImpact] 핀 충돌 프레임: $i (변화율: ${(ratio * 100).toStringAsFixed(1)}%)');
         return i;

--- a/lib/features/analysis/presentation/pages/analysis_trim_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_trim_page.dart
@@ -148,8 +148,8 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
           releaseFrame: releaseFrame,
           sampleFps: extracted.sampleFps,
         );
-        speedKmh = geminiResult.speedKmh;
-        rpm = geminiResult.rpmEstimated;
+        speedKmh = geminiResult.data.speedKmh;
+        rpm = geminiResult.data.rpmEstimated;
         debugPrint('[Trim] Gemini 통합 결과: ${speedKmh?.toStringAsFixed(1) ?? '측정불가'}km/h, RPM=$rpm');
       } on GeminiQuotaExceededException {
         debugPrint('[Trim] Gemini 할당량 초과 → 로컬 폴백');

--- a/lib/features/analysis/presentation/pages/analysis_trim_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_trim_page.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:image/image.dart' as img;
 import 'package:path_provider/path_provider.dart';
 import 'package:video_player/video_player.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
@@ -151,6 +153,9 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
         speedKmh = geminiResult.data.speedKmh;
         rpm = geminiResult.data.rpmEstimated;
         debugPrint('[Trim] Gemini 통합 결과: ${speedKmh?.toStringAsFixed(1) ?? '측정불가'}km/h, RPM=$rpm');
+        if (kDebugMode && geminiResult.landmarkFrames != null && mounted) {
+          _showLandmarkDebug(geminiResult);
+        }
       } on GeminiQuotaExceededException {
         debugPrint('[Trim] Gemini 할당량 초과 → 로컬 폴백');
       } catch (e) {
@@ -214,6 +219,55 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
     final m = (seconds ~/ 60).toString().padLeft(2, '0');
     final s = (seconds % 60).toStringAsFixed(1).padLeft(4, '0');
     return '$m:$s';
+  }
+
+  void _showLandmarkDebug(GeminiAnalysisResult result) {
+    final landmarks = result.landmarkFrames!;
+    final frames = result.sampledFrames ?? [];
+    const labels = {'foul_line': '파울라인', 'arrows': '화살표', 'headpin': '헤드핀'};
+
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('[DEBUG] Gemini 랜드마크'),
+        content: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: labels.entries.map((e) {
+              final frameIdx = landmarks[e.key];
+              if (frameIdx == null || frameIdx >= frames.length) {
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Text('${e.value}: null',
+                      style: const TextStyle(color: Colors.red)),
+                );
+              }
+              final jpgBytes =
+                  Uint8List.fromList(img.encodeJpg(frames[frameIdx]));
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('${e.value} (프레임 $frameIdx)',
+                        style:
+                            const TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 4),
+                    Image.memory(jpgBytes, height: 120, fit: BoxFit.contain),
+                  ],
+                ),
+              );
+            }).toList(),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('닫기'),
+          ),
+        ],
+      ),
+    );
   }
 
   @override

--- a/lib/features/analysis/presentation/pages/analysis_trim_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_trim_page.dart
@@ -154,7 +154,7 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
         rpm = geminiResult.data.rpmEstimated;
         debugPrint('[Trim] Gemini 통합 결과: ${speedKmh?.toStringAsFixed(1) ?? '측정불가'}km/h, RPM=$rpm');
         if (kDebugMode && geminiResult.landmarkFrames != null && mounted) {
-          _showLandmarkDebug(geminiResult);
+          await _showLandmarkDebug(geminiResult);
         }
       } on GeminiQuotaExceededException {
         debugPrint('[Trim] Gemini 할당량 초과 → 로컬 폴백');
@@ -221,7 +221,7 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
     return '$m:$s';
   }
 
-  void _showLandmarkDebug(GeminiAnalysisResult result) {
+  Future<void> _showLandmarkDebug(GeminiAnalysisResult result) async {
     final landmarks = result.landmarkFrames!;
     final frames = result.sampledFrames ?? [];
     const labels = {'foul_line': '파울라인', 'arrows': '화살표', 'headpin': '헤드핀'};

--- a/lib/features/analysis/presentation/pages/analysis_trim_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_trim_page.dart
@@ -1,8 +1,6 @@
 import 'dart:io';
 import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:image/image.dart' as img;
 import 'package:path_provider/path_provider.dart';
 import 'package:video_player/video_player.dart';
 import 'package:bowling_diary/app/theme/app_colors.dart';
@@ -150,12 +148,9 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
           releaseFrame: releaseFrame,
           sampleFps: extracted.sampleFps,
         );
-        speedKmh = geminiResult.data.speedKmh;
-        rpm = geminiResult.data.rpmEstimated;
+        speedKmh = geminiResult.speedKmh;
+        rpm = geminiResult.rpmEstimated;
         debugPrint('[Trim] Gemini 통합 결과: ${speedKmh?.toStringAsFixed(1) ?? '측정불가'}km/h, RPM=$rpm');
-        if (kDebugMode && geminiResult.landmarkFrames != null && mounted) {
-          await _showLandmarkDebug(geminiResult);
-        }
       } on GeminiQuotaExceededException {
         debugPrint('[Trim] Gemini 할당량 초과 → 로컬 폴백');
       } catch (e) {
@@ -219,55 +214,6 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
     final m = (seconds ~/ 60).toString().padLeft(2, '0');
     final s = (seconds % 60).toStringAsFixed(1).padLeft(4, '0');
     return '$m:$s';
-  }
-
-  Future<void> _showLandmarkDebug(GeminiAnalysisResult result) async {
-    final landmarks = result.landmarkFrames!;
-    final frames = result.sampledFrames ?? [];
-    const labels = {'foul_line': '파울라인', 'arrows': '화살표', 'headpin': '헤드핀'};
-
-    showDialog<void>(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('[DEBUG] Gemini 랜드마크'),
-        content: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: labels.entries.map((e) {
-              final frameIdx = landmarks[e.key];
-              if (frameIdx == null || frameIdx >= frames.length) {
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 8),
-                  child: Text('${e.value}: null',
-                      style: const TextStyle(color: Colors.red)),
-                );
-              }
-              final jpgBytes =
-                  Uint8List.fromList(img.encodeJpg(frames[frameIdx]));
-              return Padding(
-                padding: const EdgeInsets.only(bottom: 12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text('${e.value} (프레임 $frameIdx)',
-                        style:
-                            const TextStyle(fontWeight: FontWeight.bold)),
-                    const SizedBox(height: 4),
-                    Image.memory(jpgBytes, height: 120, fit: BoxFit.contain),
-                  ],
-                ),
-              );
-            }).toList(),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('닫기'),
-          ),
-        ],
-      ),
-    );
   }
 
   @override

--- a/test/features/analysis/data/services/pin_impact_detector_service_test.dart
+++ b/test/features/analysis/data/services/pin_impact_detector_service_test.dart
@@ -2,57 +2,44 @@ import 'package:bowling_diary/features/analysis/data/services/pin_impact_detecto
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 
-img.Image _grayFrame(int w, int h, int lum) {
-  final frame = img.Image(width: w, height: h);
-  img.fill(frame, color: img.ColorRgb8(lum, lum, lum));
-  return frame;
-}
+img.Image _blackFrame(int w, int h) => img.Image(width: w, height: h)
+  ..clear(img.ColorRgb8(0, 0, 0));
 
-img.Image _frameWithPinExplosion(int w, int h) {
-  // 상단 20%를 흰색(255)으로 → 직전 프레임 대비 급격한 변화
-  final frame = img.Image(width: w, height: h);
-  img.fill(frame, color: img.ColorRgb8(128, 128, 128));
-  final pinZoneH = (h * 0.20).round();
-  for (int y = 0; y < pinZoneH; y++) {
-    for (int x = 0; x < w; x++) {
-      frame.setPixelRgb(x, y, 255, 255, 255);
-    }
-  }
-  return frame;
-}
+img.Image _whiteFrame(int w, int h) => img.Image(width: w, height: h)
+  ..clear(img.ColorRgb8(255, 255, 255));
 
 void main() {
   late PinImpactDetectorService sut;
-
   setUp(() => sut = PinImpactDetectorService());
 
-  test('프레임 없으면 null', () {
-    expect(sut.findImpactFrame([], 0), isNull);
-  });
-
-  test('릴리즈 프레임 이후 변화 없으면 null', () {
-    final frames = List.generate(10, (_) => _grayFrame(120, 100, 128));
-    expect(sut.findImpactFrame(frames, 2), isNull);
-  });
-
-  test('핀 충돌 프레임 감지', () {
-    final frames = [
-      _grayFrame(120, 100, 128), // 0 릴리즈 전
-      _grayFrame(120, 100, 128), // 1 릴리즈
-      _grayFrame(120, 100, 128), // 2 이동 중
-      _grayFrame(120, 100, 128), // 3 이동 중
-      _frameWithPinExplosion(120, 100), // 4 충돌!
+  test('릴리즈 직후(minTravelFrames 이내) 큰 변화는 무시', () {
+    final frames = <img.Image>[
+      ...List.generate(10, (_) => _blackFrame(100, 100)),
+      ...List.generate(10, (_) => _whiteFrame(100, 100)),
+      ...List.generate(30, (_) => _blackFrame(100, 100)),
     ];
-    expect(sut.findImpactFrame(frames, 1), equals(4));
+    final result = sut.findImpactFrame(frames, 0);
+    expect(result, isNull);
   });
 
-  test('릴리즈 이전 충돌은 무시', () {
-    final frames = [
-      _frameWithPinExplosion(120, 100), // 0 (릴리즈 전)
-      _grayFrame(120, 100, 128),         // 1 릴리즈
-      _grayFrame(120, 100, 128),         // 2
+  test('minTravelFrames 이후 큰 변화는 충돌로 감지', () {
+    final frames = <img.Image>[
+      ...List.generate(25, (_) => _blackFrame(100, 100)),
+      _whiteFrame(100, 100),
+      ...List.generate(10, (_) => _blackFrame(100, 100)),
     ];
-    // releaseFrame=1 이후엔 변화 없음 → null
-    expect(sut.findImpactFrame(frames, 1), isNull);
+    final result = sut.findImpactFrame(frames, 0);
+    expect(result, isNotNull);
+    expect(result!, greaterThanOrEqualTo(20));
+  });
+
+  test('프레임 부족 시 null', () {
+    final frames = List.generate(5, (_) => _blackFrame(100, 100));
+    expect(sut.findImpactFrame(frames, 0), isNull);
+  });
+
+  test('releaseFrame이 후반부라 searchStart >= frames.length 이면 null', () {
+    final frames = List.generate(25, (_) => _blackFrame(100, 100));
+    expect(sut.findImpactFrame(frames, 20), isNull);
   });
 }

--- a/test/features/analysis/data/services/pin_impact_detector_service_test.dart
+++ b/test/features/analysis/data/services/pin_impact_detector_service_test.dart
@@ -2,8 +2,7 @@ import 'package:bowling_diary/features/analysis/data/services/pin_impact_detecto
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 
-img.Image _blackFrame(int w, int h) => img.Image(width: w, height: h)
-  ..clear(img.ColorRgb8(0, 0, 0));
+img.Image _blackFrame(int w, int h) => img.Image(width: w, height: h);
 
 img.Image _whiteFrame(int w, int h) => img.Image(width: w, height: h)
   ..clear(img.ColorRgb8(255, 255, 255));


### PR DESCRIPTION
## 🚨 긴급 수정 — v1.2.1

### 문제
앱스토어 배포 버전(v1.2.0)에서 Gemini OCR 작동 불가 및 분석 탭 비정상 노출.

### 변경 사항

#### 1. Gemini API 키 누락
- `GEMINI_API_KEY` GitHub Secret 비어있어 컴파일 타임에 빈 문자열 주입
- `String.fromEnvironment` 특성상 런타임 복구 불가 → OCR 즉시 실패
- Secret 업데이트 완료, 재빌드 시 정상 작동
- 관련 이슈: #31

#### 2. 분석 탭 임시 비활성화
- 앱스토어 이슈로 바텀 네비게이션 분석 탭 주석 처리
- 마이페이지 인덱스 3 → 2 조정

### 확인
- [ ] CI/CD 빌드 성공
- [ ] TestFlight Gemini OCR 정상 작동