### PR TITLE
chore: 버전 1.3.0+2로 bump

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bowling_diary
 description: "볼링 기록 & 분석 앱 - 나의 볼링 성장 일기장"
 publish_to: 'none'
-version: 1.2.0+1
+version: 1.3.0+2
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
## Summary
- pubspec.yaml의 version을 `1.2.0+1` → `1.3.0+2`로 변경
- 직전 dev 빌드(run 25745906484)에서 TestFlight 업로드가 `Invalid Pre-Release Train` / `CFBundleShortVersionString must contain a higher version` 검증 에러로 거부됨
- App Store Connect의 1.2.0 train이 이미 closed 상태라 같은 short version 재업로드 불가

## Test plan
- [ ] dev 머지 후 TestFlight 업로드 워크플로 성공 확인
- [ ] App Store Connect 빌드 목록에 1.3.0 (Build 2) 등장 확인

## 별건
- altool이 업로드 검증 실패 시에도 exit 0을 반환해 워크플로가 success로 잘못 마킹됨. 후속 PR에서 step에 실패 감지 로직 추가 필요.