### PR TITLE
fix(analysis): 프레임별 검출 실패로 인한 전체 분석 중단 방어

### DIFF
--- a/lib/features/analysis/data/services/analysis_pipeline.dart
+++ b/lib/features/analysis/data/services/analysis_pipeline.dart
@@ -9,6 +9,7 @@ import 'package:bowling_diary/features/analysis/domain/entities/homography_matri
 import 'package:bowling_diary/features/analysis/domain/entities/release_result.dart';
 import 'package:bowling_diary/features/analysis/domain/entities/speed_result.dart';
 import 'package:bowling_diary/features/analysis/domain/services/analysis_state_machine.dart';
+import 'package:flutter/foundation.dart' show debugPrint;
 
 class AnalysisPipeline {
   final VideoFrameExtractorService frameExtractor;
@@ -78,8 +79,22 @@ class AnalysisPipeline {
 
     List<BallDetection?> detections;
     try {
+      // 모델 로드 자체가 실패하면(GPU/CPU 둘 다 실패) 0프레임 분석은 의미가 없으므로
+      // 여기서는 예외를 그대로 전파해 analysis_trim_page의 상위 핸들러가 처리하게 둔다.
       await ballDetector.init();
-      detections = frames.map((f) => ballDetector.detect(f)).toList();
+
+      // 반면 프레임 단위 검출 실패는 치명적이지 않다 — 다운스트림(release/impact/speed
+      // estimator)이 이미 null 검출을 1급 케이스로 처리하도록 설계돼 있으므로, 개별
+      // 프레임에서 예외가 나도 해당 프레임만 null로 격하시키고 나머지는 계속 진행한다.
+      detections = <BallDetection?>[];
+      for (var i = 0; i < frames.length; i++) {
+        try {
+          detections.add(ballDetector.detect(frames[i]));
+        } catch (e) {
+          debugPrint('[AnalysisPipeline] frame $i 검출 실패: $e');
+          detections.add(null);
+        }
+      }
     } finally {
       ballDetector.dispose();
     }

--- a/test/features/analysis/data/services/analysis_pipeline_test.dart
+++ b/test/features/analysis/data/services/analysis_pipeline_test.dart
@@ -34,6 +34,27 @@ class _FakeBallDetector implements BallDetectionService {
   BallDetection? detect(img.Image frame) => _i < sequence.length ? sequence[_i++] : null;
 }
 
+/// [failFrames]에 해당하는 프레임 인덱스에서 detect()가 예외를 던지는 페이크.
+/// 프레임 단위 검출 실패가 파이프라인 전체를 죽이지 않는지 검증하기 위한 회귀 테스트용.
+class _FlakyFakeBallDetector implements BallDetectionService {
+  final List<BallDetection?> sequence;
+  final Set<int> failFrames;
+  int _i = 0;
+  _FlakyFakeBallDetector(this.sequence, this.failFrames);
+  @override
+  Future<void> init() async {}
+  @override
+  void dispose() {}
+  @override
+  BallDetection? detect(img.Image frame) {
+    final i = _i++;
+    if (failFrames.contains(i)) {
+      throw StateError('synthetic per-frame detection failure at $i');
+    }
+    return i < sequence.length ? sequence[i] : null;
+  }
+}
+
 img.Image _blankFrame() {
   final image = img.Image(width: 20, height: 20);
   img.fill(image, color: img.ColorRgb8(10, 10, 10));
@@ -133,6 +154,32 @@ void main() {
 
     expect(result.framesAnalyzed, detections.length);
   });
+
+  test(
+    '특정 프레임에서 ballDetector.detect()가 예외를 던져도(예: TFLite 엣지 케이스) '
+    '해당 프레임만 null로 격하되고 파이프라인 전체는 중단 없이 완주해 속도를 산출한다',
+    () async {
+      final detections = _regressionDetections();
+      final frames = _regressionFrames();
+
+      final pipeline = AnalysisPipeline(
+        frameExtractor: _FakeFrameExtractor(
+          FrameExtractionResult(frames: frames, originalFps: 30, sampleFps: 30),
+        ),
+        ballDetector: _FlakyFakeBallDetector(detections, const {10}),
+        releaseDetector: ReleaseDetectorService(),
+        impactDetector: ImpactDetectorService(pinImpactDetector: PinImpactDetectorService()),
+        speedEstimator: SpeedEstimatorService(),
+      );
+
+      final result = await pipeline.run('fake.mp4', homography);
+
+      expect(result.framesAnalyzed, detections.length);
+      expect(result.speedFailure, isNull);
+      expect(result.speedKmh, isNotNull);
+      expect(result.speedKmh, inInclusiveRange(10.0, 50.0));
+    },
+  );
 
   group('AnalysisPipeline.combineRelease', () {
     test('FSM 찾음 + detector 근접 일치(10프레임 이내) → high confidence로 FSM 프레임 채택', () {


### PR DESCRIPTION
## Summary
테플 실기기 테스트 중 "분석 중 문제가 발생했어요" 리포트 발생(로딩화면 중간 실패). 크래시 리포팅 도구 미연동이라 정확한 예외 특정은 아직 불가능하지만, 구조적으로 확실히 틀린 지점 발견해 방어 조치:

- `AnalysisPipeline.run()`의 프레임별 YOLO 검출 루프(`frames.map((f) => ballDetector.detect(f)).toList()`)에 프레임 단위 예외처리가 전혀 없었음 — 150프레임 중 단 1개라도 검출에서 예외 던지면 전체 분석이 그 자리에서 죽음
- 근데 이 시스템은 애초에 검출 실패(null)를 감내하게 설계돼있음 — release detector/FSM/speed estimator 전부 null 검출 스킵 처리 이미 함
- 프레임 단위 실패를 null로 격하시켜 나머지 파이프라인이 계속 진행되게 수정. 진단용 debugPrint(프레임 인덱스+예외)는 추후 Xcode 콘솔 연결 시 원인 특정용

## 한계
코드 리딩 기반 진단이지 실제 크래시 재현은 아님 — 만약 실패 원인이 프레임별 detect() 예외가 아니라면 이걸로 안 잡힐 수 있음. 다음 테스트 때 폰 USB 연결해서 Xcode 디바이스 콘솔 로그 확인하면 원인 확정 가능.

## Test plan
- [x] `flutter test test/features/analysis/ test/golden_reference/` — 58/58 통과
- [x] `flutter analyze` — 0 errors
- [ ] 실기기 재QA