### PR TITLE
fix(ios): 아카이브 strip이 TFLite 심볼 제거 → 분석 항상 실패

### DIFF
--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,11 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+
+// tflite_flutter는 iOS에서 DynamicLibrary.process()로 TensorFlowLiteC 심볼을
+// 런타임에 dlsym 조회한다. Xcode 기본값(STRIP_STYLE=all)으로 아카이브하면
+// strip이 실행 파일 export trie에서 전역 심볼을 지워
+// `Failed to lookup symbol 'TfLiteInterpreterOptionsCreate'`로 죽는다.
+// `flutter build ios`는 strip을 돌리지 않아 로컬 릴리즈 빌드는 멀쩡하고
+// `xcodebuild archive`만 실패한다 — TestFlight에서만 재현되던 이유.
+// non-global은 로컬 심볼만 제거하므로 바이너리 크기 감소폭은 all과 동일하다.
+STRIP_STYLE = non-global


### PR DESCRIPTION
## 증상

TestFlight에서 분석이 **매번** 실패. PR #42로 넣은 진단 로그가 원인을 그대로 잡아냄:

```
Invalid argument(s): Failed to lookup symbol 'TfLiteInterpreterOptionsCreate':
dlsym(RTLD_DEFAULT, TfLiteInterpreterOptionsCreate): symbol not found
```

스택: `ball_detection_service.dart:115` (`InterpreterOptions()`) — GPU 시도와 CPU 폴백이 **같은 지점**에서 죽어 폴백이 무의미했음.

파이프라인 앞단은 정상이었다: `[FrameExtractor] 추출 완료: 210개 프레임`.

## 원인

1. `tflite_flutter`는 iOS에서 `DynamicLibrary.process()`를 쓴다 — TensorFlowLiteC 심볼을 런타임에 `dlsym`으로 찾음
2. Xcode 기본값 `STRIP_STYLE = all`
3. `xcodebuild archive`가 실행 파일 export trie에서 전역 심볼을 제거
4. `dlsym` 실패

`flutter build ios --release`는 strip을 돌리지 않는다. 그래서 **로컬 릴리즈 빌드는 정상**이고 CI의 `xcodebuild archive`만 깨져 TestFlight에서만 재현됐다.

## 수정

`ios/Flutter/Release.xcconfig`에 `STRIP_STYLE = non-global` (Runner Release 베이스 컨피그).

## 검증

| 단계 | TFLite export 심볼 |
|---|---|
| `flutter build ios --release` 산출물 (56MB) | 2 |
| 위 바이너리에 `strip`(=all) 수동 실행 (41MB) | **0** ← TestFlight 증상 재현 |
| 위 바이너리에 `strip -x`(non-global) (41MB) | 2 |
| 수정 후 `xcodebuild archive` (40.5MB, ARCHIVE SUCCEEDED) | **2** |

크기 감소폭이 `all`과 동일(41MB) — non-global 전환 비용 없음.

## 참고

CI가 `--build-number=$((GITHUB_RUN_NUMBER + 10))`으로 빌드번호를 덮어쓴다. pubspec의 빌드번호는 무시되고 실제 배포는 `1.3.0+44`였다. 앞으로 빌드번호 수동 bump 불필요.