### PR TITLE
fix(analysis): 화살표 검출 원본 해상도 사용 + 구속·궤적 진단 보강

### DIFF
--- a/lib/features/analysis/data/services/analysis_pipeline.dart
+++ b/lib/features/analysis/data/services/analysis_pipeline.dart
@@ -145,7 +145,14 @@ class AnalysisPipeline {
     required int impactFrame,
     required int sampleFps,
   }) {
-    final line = arrowLineFromDetections(detectArrows(releaseFrame));
+    // 실패가 "검출 0개"인지 "검출은 됐는데 선을 못 세움"인지 구분되지 않으면
+    // 튜닝 방향을 정할 수 없다 — 실기기 1회 실패에 빌드 1회를 쓰게 된다.
+    final arrows = detectArrows(releaseFrame);
+    final line = arrowLineFromDetections(arrows);
+    debugPrint('[Arrow] 입력 ${releaseFrame.width}x${releaseFrame.height}, '
+        '검출 ${arrows.length}개'
+        '${arrows.isEmpty ? "" : " ${arrows.map((a) => "(${a.nx.toStringAsFixed(3)},${a.ny.toStringAsFixed(3)})").join(" ")}"}, '
+        '선 ${line == null ? "실패" : "성립"}');
     if (line == null) return null;
     return estimateLandmarkSpeedKmh(
       track: [for (final s in pixelTrack) (frame: s.frame, p: s.contact)],
@@ -197,7 +204,16 @@ class AnalysisPipeline {
 
   /// [homography]는 이 영상 전용으로 산출된 호모그래피다(레퍼런스 = 영상 자체이므로
   /// drift 개념이 존재하지 않는다 — spec §10 참조).
-  Future<AnalysisData> run(String videoPath, HomographyMatrix homography) async {
+  /// [landmarkFrame]은 조준 화살표 검출 전용 고해상도 프레임이다. 분석 프레임은
+  /// 폭 480 + jpeg q5로 뽑히는데, 화살표는 그 해상도에서 뭉개져 검출이 깨진다.
+  /// 화살표는 레인에 고정된 마킹이라 어느 프레임을 써도 무방하므로, 호출부가
+  /// 이미 원본 해상도로 뽑아둔 첫 프레임을 그대로 넘긴다. 없으면 릴리즈 프레임
+  /// 폴백.
+  Future<AnalysisData> run(
+    String videoPath,
+    HomographyMatrix homography, {
+    img.Image? landmarkFrame,
+  }) async {
     final extracted = await frameExtractor.extract(videoPath);
     final frames = extracted.frames;
     if (frames.isEmpty) {
@@ -346,6 +362,19 @@ class AnalysisPipeline {
     debugPrint('[Trajectory] 리본 소스: ${trajectorySource.label} '
         '(${finalTrajectory.length}개 단면, 픽셀관측 ${pixelTrack.length}개'
         '${pixelRibbon != null ? ", rms ${pixelRibbon.rms.toStringAsFixed(5)}" : ""})');
+    // 리본이 핀까지 닿는지는 끝점 ny를 핀존 ny와 직접 비교해야 판정된다.
+    // "선이 BP에서 끝난다"가 연장 실패인지 원근 압축인지 이 한 줄로 갈린다.
+    if (finalTrajectory.isNotEmpty) {
+      final head = finalTrajectory.first;
+      final tail = finalTrajectory.last;
+      final lastObserved = pixelTrack.isEmpty ? null : pixelTrack.last;
+      debugPrint('[Trajectory] 리본 f${head.frame}~f${tail.frame} '
+          'ny ${((head.left.ny + head.right.ny) / 2).toStringAsFixed(3)}'
+          '→${((tail.left.ny + tail.right.ny) / 2).toStringAsFixed(3)}, '
+          '마지막 관측 f${lastObserved?.frame} ny '
+          '${lastObserved?.contact.ny.toStringAsFixed(3) ?? "없음"}, '
+          '핀존 ny ${pinZone == null ? "없음" : "${pinZone.top.toStringAsFixed(3)}~${pinZone.bottom.toStringAsFixed(3)}"}');
+    }
 
     final speed = speedEstimator.estimate(
       release: release,
@@ -356,7 +385,7 @@ class AnalysisPipeline {
 
     // 랜드마크 통과-시각 구속 — 조준 화살표가 검출되면 이쪽이 1순위.
     final landmarkKmh = estimateLandmarkSpeed(
-      releaseFrame: frames[releaseFrameIdx],
+      releaseFrame: landmarkFrame ?? frames[releaseFrameIdx],
       pixelTrack: pixelTrack,
       impactFrame: impact.frame,
       sampleFps: extracted.sampleFps,

--- a/lib/features/analysis/presentation/pages/analysis_trim_page.dart
+++ b/lib/features/analysis/presentation/pages/analysis_trim_page.dart
@@ -174,7 +174,10 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
         impactDetector: ImpactDetectorService(pinImpactDetector: PinImpactDetectorService()),
         speedEstimator: SpeedEstimatorService(),
       );
-      final analysisData = await pipeline.run(trimmedPath, homography);
+      // 화살표 검출은 분석 프레임(폭 480, jpeg q5)에선 뭉개진다 — 레인 확인용으로
+      // 이미 원본 해상도로 뽑아둔 첫 프레임을 그대로 넘긴다.
+      final analysisData =
+          await pipeline.run(trimmedPath, homography, landmarkFrame: frame);
 
       // 성공 케이스도 남긴다 — 구속 두 코어 값이 매 투구 쌓여야 표본 1개가
       // 아닌 분포로 정확도를 판단할 수 있다. await하지 않는다(결과 화면 지연 방지).
@@ -192,6 +195,23 @@ class _AnalysisTrimPageState extends State<AnalysisTrimPage> {
           'trajectory_source': analysisData.trajectorySource?.name,
           'trajectory_fit_rms': analysisData.trajectoryFitRms,
           'trajectory_points': analysisData.trajectory.length,
+          // 리본이 핀까지 닿는지 SQL만으로 판정하기 위한 끝점(깊이축 정규화 좌표).
+          'trajectory_first_frame': analysisData.trajectory.isEmpty
+              ? null
+              : analysisData.trajectory.first.frame,
+          'trajectory_last_frame': analysisData.trajectory.isEmpty
+              ? null
+              : analysisData.trajectory.last.frame,
+          'trajectory_first_ny': analysisData.trajectory.isEmpty
+              ? null
+              : (analysisData.trajectory.first.left.ny +
+                      analysisData.trajectory.first.right.ny) /
+                  2,
+          'trajectory_last_ny': analysisData.trajectory.isEmpty
+              ? null
+              : (analysisData.trajectory.last.left.ny +
+                      analysisData.trajectory.last.right.ny) /
+                  2,
           'entry_angle_deg': analysisData.entryAngleDeg,
           'trim_start_sec': _startSec,
           'trim_end_sec': _endSec,


### PR DESCRIPTION
## 실기기 1회차 결과 (1.3.0+45)

분석 성공. 진단 로그로 두 문제의 원인이 좁혀짐.

```
[BallDetection] 검출 73/210 프레임, 최고 점수 0.875
[ReleaseDetector] release=67, conf=0.4
[Trajectory] refined f71~f114 (lane y 2.1 → 13.5m)
[PinImpact] 핀 폭발 프레임: 124
[Trajectory] 리본 소스: 픽셀투영 (59개 단면, 관측 37개, rms 0.00062)
[SpeedEstimator] 32.7km/h (파울라인통과 f=63.6, 폭발 f=124, 회귀 28.7, R² 1.00)
[Speed] 랜드마크 없음km/h, 기존 32.7km/h → 채택 32.7km/h(기존)
```

### 구속이 높은 이유

`landmark_speed_kmh = null` — **화살표 검출 실패로 랜드마크 코어가 죽고 legacy 폴백**. legacy는 원근 압축에 취약해 재설계 대상이었던 그 코어다.

legacy 내부에서도 두 추정이 어긋난다:
- 회귀 기울기: **28.7 km/h** (추적 구간 2.1~13.5m)
- 이벤트 시간: **32.7 km/h** (파울라인 f63.6 → 폭발 f124)

게다가 파울라인 통과가 f=63.6인데 릴리즈는 f=66~67 — **공이 릴리즈보다 3.4프레임 먼저 파울라인을 넘었다는 모순**. 호모그래피 레인 y가 신뢰할 수 없다는 직접 증거.

### 궤적이 BP에서 끝나 보이는 건

코드상 리본은 f66~f124 **59개 단면 전부** 생성됨(관측 37 + 모델 연장 22). 끊기지 않는다. 남은 가능성은 연장 구간이 소실점 근처라 픽셀 이동이 거의 없는 것 — 판정하려면 리본 끝점 ny를 핀존 ny(이번 회차 0.34~0.41)와 비교해야 한다.

## 변경

### 1. 화살표 검출 입력 교체 (실질 수정)
분석 프레임은 `scale=480:-1 -q:v 5`로 뽑힌다. 화살표는 이 해상도/압축에서 뭉개진다. 화살표는 **레인에 고정된 마킹**이라 어느 프레임을 써도 무방하므로, 레인 확인용으로 이미 원본 해상도(`-q:v 3`, 스케일 없음)로 디코딩해둔 첫 프레임을 `run(landmarkFrame:)`으로 넘긴다. ffmpeg 추가 호출 없음.

### 2. 진단
- `[Arrow]` — 입력 해상도, 검출 개수, 각 좌표, 선 성립 여부. 실패가 "0개 검출"인지 "선 구성 실패"인지 구분
- `[Trajectory]` 리본 끝점 — 리본 f범위·ny범위, 마지막 관측, 핀존 ny를 한 줄에
- `metrics`에 `trajectory_first/last_frame`, `trajectory_first/last_ny` — SQL만으로 도달 판정

## 검증

- `flutter analyze lib/features/analysis/` — 신규 이슈 0 (기존 info 2건은 homography_solver 네이밍)
- `flutter test test/features/analysis` — 210 passed